### PR TITLE
fixes #59

### DIFF
--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -256,11 +256,18 @@ class Demo extends PureComponent {
         })
     }
 
-    showXena() {
+    showXena = () =>  {
+        let oldState = this.state.view ;
         this.setState({
             view: 'xena'
-        })
+        });
+        if(oldState !== 'xena'){
+            console.log('refs:',this.refs);
+            // console.log(this.refs['pathway-editor']);
+            // console.log(this.refs['pathway-editor'].multiXenaGoApp);
+        }
     }
+
 
     // just duplicate the last state
     duplicateCohort() {
@@ -282,6 +289,11 @@ class Demo extends PureComponent {
         this.setState({
             synchronizeSort: !this.state.synchronizeSort
         })
+    }
+
+    componentDidUpdate(){
+        console.log('more refs:',this.refs);
+        console.log('found xena refs:',this.refs['multiXenaGoApp']);
     }
 
     toggleSynchronizeSelection() {

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -294,6 +294,9 @@ class Demo extends PureComponent {
     componentDidUpdate(){
         console.log('more refs:',this.refs);
         console.log('found xena refs:',this.refs['multiXenaGoApp']);
+        if(this.state.view==='xena'){
+            this.refs['multiXenaGoApp'].reloadCohorts();
+        }
     }
 
     toggleSynchronizeSelection() {

--- a/src/components/MultiXenaGoApp.js
+++ b/src/components/MultiXenaGoApp.js
@@ -69,6 +69,10 @@ export default class MultiXenaGoApp extends PureComponent {
 
     reloadCohorts (){
         alert('reloading the cohort')
+        return this.state.apps.map((app, index) => {
+            let refString = 'xena-go-app-' + index;
+            this.refs[refString].reloadCohort();
+        });
     };
 
     // // just duplicate the last state

--- a/src/components/MultiXenaGoApp.js
+++ b/src/components/MultiXenaGoApp.js
@@ -67,6 +67,9 @@ export default class MultiXenaGoApp extends PureComponent {
         });
     }
 
+    reloadCohorts (){
+        alert('reloading the cohort')
+    };
 
     // // just duplicate the last state
     duplicateCohort() {

--- a/src/components/XenaGoApp.js
+++ b/src/components/XenaGoApp.js
@@ -189,6 +189,7 @@ export default class XenaGoApp extends PureComponent {
             });
     }
 
+
     selectCohort = (selected) => {
         let cohort = this.state.cohortData.find(c => c.name === selected);
         this.setState({

--- a/src/components/XenaGoApp.js
+++ b/src/components/XenaGoApp.js
@@ -189,8 +189,15 @@ export default class XenaGoApp extends PureComponent {
             });
     }
 
+    reloadCohort(){
+       let selectedCohort = this.state.selectedCohort ;
+       alert(JSON.stringify(selectedCohort))
+       this.selectCohort(selectedCohort);
+    }
 
     selectCohort = (selected) => {
+        alert('selected');
+        alert(JSON.stringify(selected));
         let cohort = this.state.cohortData.find(c => c.name === selected);
         this.setState({
             selectedCohort: selected,


### PR DESCRIPTION
fixes #59 

The multiXenaGoApp seems to fall out fo scope temporarily when switching back and forth.    That is okay as `componentDidUpdate()` should be able to call a reload after picking out the view if we can somehow detect that we'd just come back.  