### PR TITLE
color by type - 223

### DIFF
--- a/src/components/FilterSelector.js
+++ b/src/components/FilterSelector.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PureComponent from './PureComponent';
 import PropTypes from 'prop-types';
 import {pick, groupBy, mapObject, pluck, flatten} from 'underscore';
-import {sum} from '../functions/util';
+import {sumTotals} from '../functions/util';
 import {Dropdown} from "react-toolbox";
 import {getCopyNumberValue} from "../functions/DataFunctions";
 
@@ -65,7 +65,7 @@ export class FilterSelector extends PureComponent {
         let counts = compileData(Object.keys(filters), pathwayData, geneList, amplificationThreshold, deletionThreshold);
         // CNV counts
         let labels = Object.keys(counts).sort(lowerCaseCompare);
-        let total = sum(Object.values(counts));
+        let total = sumTotals(Object.values(counts));
 
         const labelValues = labels.map(label => ({label: label + ' (' + counts[label] + ')', value: label}));
         labelValues.unshift({label: 'CNV + Mutation (' + total + ')', value: 'All'});

--- a/src/components/FilterSelector.js
+++ b/src/components/FilterSelector.js
@@ -1,8 +1,7 @@
 import React from 'react'
 import PureComponent from './PureComponent';
 import PropTypes from 'prop-types';
-import {pick, groupBy, mapObject, pluck, flatten} from 'underscore';
-import {sumTotals} from '../functions/util';
+import {pick, groupBy, mapObject, pluck, flatten,sum} from 'underscore';
 import {Dropdown} from "react-toolbox";
 import {getCopyNumberValue} from "../functions/DataFunctions";
 
@@ -65,7 +64,7 @@ export class FilterSelector extends PureComponent {
         let counts = compileData(Object.keys(filters), pathwayData, geneList, amplificationThreshold, deletionThreshold);
         // CNV counts
         let labels = Object.keys(counts).sort(lowerCaseCompare);
-        let total = sumTotals(Object.values(counts));
+        let total = sum(Object.values(counts));
 
         const labelValues = labels.map(label => ({label: label + ' (' + counts[label] + ')', value: label}));
         labelValues.unshift({label: 'CNV + Mutation (' + total + ')', value: 'All'});

--- a/src/components/HoverGeneView.js
+++ b/src/components/HoverGeneView.js
@@ -49,7 +49,7 @@ export default class HoverGeneView extends PureComponent {
                         }
                         {data.expression != null &&
                         <Chip>
-                            <span className={data.expression===0 ? '' : BaseStyle.highlightChip}><strong>Hits</strong> {data.expression}</span>
+                            <span className={data.expression.total===0 ? '' : BaseStyle.highlightChip}><strong>Hits</strong> {data.expression.total}</span>
                         </Chip>
                         }
                         {data.tissue &&

--- a/src/components/HoverGeneView.js
+++ b/src/components/HoverGeneView.js
@@ -49,7 +49,15 @@ export default class HoverGeneView extends PureComponent {
                         }
                         {data.expression != null &&
                         <Chip>
-                            <span className={data.expression.total===0 ? '' : BaseStyle.highlightChip}><strong>Hits</strong> {data.expression.total}</span>
+                            {data.expression.cnv!==0 &&
+                            <span
+                                className={data.expression.cnv === 0 ? '' : BaseStyle.cnvColor}><strong>CNV</strong> {data.expression.cnv}</span>
+                            }
+                            {data.expression.mutation!==0 &&
+                            <span
+                                className={data.expression.mutation === 0 ? '' : BaseStyle.mutationColor}> <strong>Mut</strong> {data.expression.mutation}</span>
+                            }
+                            {/*<span className={data.expression.total===0 ? '' : BaseStyle.highlightChip}><strong>Hits</strong> {data.expression.total}</span>*/}
                         </Chip>
                         }
                         {data.tissue &&

--- a/src/components/NavigationBar.js
+++ b/src/components/NavigationBar.js
@@ -41,8 +41,9 @@ export default class NavigationBar extends PureComponent {
     };
 
     render() {
-        let {editGeneSetColors, showPathways, showXena, view, toggleShowReciprocalPathway, downloadRawHandler, showReciprocalPathway} = this.props;
+        let {editGeneSetColors, showPathways, showXena, view, showColorByType, toggleShowColorByType, toggleShowReciprocalPathway, downloadRawHandler, showReciprocalPathway} = this.props;
         let showReciprocalPathwayLabel = (showReciprocalPathway ? 'Hide' : 'Show') + ' Reciprocal Gene Set';
+        let showColorByTypeLabel = (showColorByType ? 'Hide' : 'Show') + ' Color By Type Gene Set';
         return (
             <div>
                 <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
@@ -54,14 +55,10 @@ export default class NavigationBar extends PureComponent {
                             <tr>
                                 <td width="5%">
                                     <Button icon='help' floating primary mini
-                                     onClick={ () => this.showHelp() }
+                                            onClick={() => this.showHelp()}
                                     />
-                                    {/*<IconMenu icon='more_vert' position='topLeft'*/}
-                                              {/*className={BaseStyle.menuStyle}>*/}
-                                    {/*</IconMenu>*/}
                                 </td>
                                 <td width="8%">
-                                    {/*https://material.io/tools/icons/?style=baseline*/}
                                     <IconMenu icon='more_vert' position='topLeft'
                                               className={BaseStyle.menuStyle}>
 
@@ -76,9 +73,12 @@ export default class NavigationBar extends PureComponent {
                                                   caption='Show GeneSet Viewer'/>
                                         }
                                         <MenuDivider/>
-                                        <MenuItem value='showRecipricalPathways'
+                                        <MenuItem value='showReciprocalPathways'
                                                   onClick={() => toggleShowReciprocalPathway()}
                                                   caption={showReciprocalPathwayLabel}/>
+                                        <MenuItem value='showColorByType'
+                                                  onClick={() => toggleShowColorByType()}
+                                                  caption={showColorByTypeLabel}/>
                                         <MenuDivider/>
                                         <MenuItem value='cohortDownload1' onClick={() => downloadRawHandler(0)}
                                                   icon='cloud_download'
@@ -134,4 +134,5 @@ NavigationBar.propTypes = {
     downloadRawHandler: PropTypes.any,
     toggleShowReciprocalPathway: PropTypes.any,
     showReciprocalPathway: PropTypes.any,
+    toggleShowColorByType: PropTypes.any,
 };

--- a/src/components/PathwayScoresView.js
+++ b/src/components/PathwayScoresView.js
@@ -271,7 +271,7 @@ export default class PathwayScoresViewCache extends PureComponent {
         let samplesLength = returnedValue.data[0].length;
         for (let d in returnedValue.data) {
             returnedValue.pathways[d].total = samplesLength;
-            returnedValue.pathways[d].affected = sum(returnedValue.data[d]);
+            returnedValue.pathways[d].affected = sum(returnedValue.data[d].total);
         }
 
         internalData = returnedValue.data;

--- a/src/components/PathwayScoresView.js
+++ b/src/components/PathwayScoresView.js
@@ -250,6 +250,7 @@ export default class PathwayScoresViewCache extends PureComponent {
             PathwayScoresView.synchronizedGeneList = PathwayScoresView.synchronizedGeneList ? PathwayScoresView.synchronizedGeneList : [];
             returnedValue = synchronizedSort(prunedColumns, PathwayScoresView.synchronizedGeneList);
         }
+        console.log('returned value',returnedValue)
         returnedValue.index = cohortIndex;
 
         // fix for #194

--- a/src/components/PathwayScoresView.js
+++ b/src/components/PathwayScoresView.js
@@ -3,7 +3,7 @@ import PureComponent from './PureComponent';
 import PropTypes from 'prop-types';
 import CanvasDrawing from "./CanvasDrawing";
 import DrawFunctions from '../functions/DrawFunctions';
-import {partition, sumInstances} from '../functions/util';
+import {partition, sumInstances, sumTotals} from '../functions/util';
 import LabelWrapper from "./LabelWrapper";
 import {clusterSort, synchronizedSort} from '../functions/SortFunctions';
 import {findAssociatedData, findPruneData} from '../functions/DataFunctions';
@@ -114,8 +114,8 @@ class PathwayScoresView extends PureComponent {
 
     onHover = (event) => {
         let {onHover} = this.props;
-        if (onHover) {
-            let pointData = getPointData(event, this.props);
+        let pointData = getPointData(event, this.props);
+        if (pointData) {
             onHover(pointData);
         }
         else {
@@ -126,7 +126,7 @@ class PathwayScoresView extends PureComponent {
 
     render() {
         const {
-            loading, width, height, layout, data, associateData, offset, cohortIndex,
+            width, height, layout, data, associateData, offset, cohortIndex,
             selectedPathways, hoveredPathways, colorSettings, highlightedGene
         } = this.props;
 
@@ -271,7 +271,7 @@ export default class PathwayScoresViewCache extends PureComponent {
         let samplesLength = returnedValue.data[0].length;
         for (let d in returnedValue.data) {
             returnedValue.pathways[d].total = samplesLength;
-            returnedValue.pathways[d].affected = sum(returnedValue.data[d].total);
+            returnedValue.pathways[d].affected = sumTotals(returnedValue.data[d]);
         }
 
         internalData = returnedValue.data;

--- a/src/components/PathwayScoresView.js
+++ b/src/components/PathwayScoresView.js
@@ -250,7 +250,6 @@ export default class PathwayScoresViewCache extends PureComponent {
             PathwayScoresView.synchronizedGeneList = PathwayScoresView.synchronizedGeneList ? PathwayScoresView.synchronizedGeneList : [];
             returnedValue = synchronizedSort(prunedColumns, PathwayScoresView.synchronizedGeneList);
         }
-        console.log('returned value',returnedValue)
         returnedValue.index = cohortIndex;
 
         // fix for #194

--- a/src/components/PathwayScoresView.js
+++ b/src/components/PathwayScoresView.js
@@ -140,7 +140,6 @@ class PathwayScoresView extends PureComponent {
                     selectedPathways={selectedPathways}
                     associateData={associateData}
                     cohortIndex={cohortIndex}
-                    data={data}
                 />
                 <LabelWrapper
                     width={width}

--- a/src/components/PathwayScoresView.js
+++ b/src/components/PathwayScoresView.js
@@ -248,6 +248,7 @@ export default class PathwayScoresViewCache extends PureComponent {
         }
         else {
             PathwayScoresView.synchronizedGeneList = PathwayScoresView.synchronizedGeneList ? PathwayScoresView.synchronizedGeneList : [];
+            console.log('PSV A',prunedColumns)
             returnedValue = synchronizedSort(prunedColumns, PathwayScoresView.synchronizedGeneList);
         }
         returnedValue.index = cohortIndex;

--- a/src/components/PathwayScoresView.js
+++ b/src/components/PathwayScoresView.js
@@ -248,7 +248,6 @@ export default class PathwayScoresViewCache extends PureComponent {
         }
         else {
             PathwayScoresView.synchronizedGeneList = PathwayScoresView.synchronizedGeneList ? PathwayScoresView.synchronizedGeneList : [];
-            console.log('PSV A',prunedColumns)
             returnedValue = synchronizedSort(prunedColumns, PathwayScoresView.synchronizedGeneList);
         }
         returnedValue.index = cohortIndex;

--- a/src/components/PathwayScoresView.js
+++ b/src/components/PathwayScoresView.js
@@ -127,7 +127,8 @@ class PathwayScoresView extends PureComponent {
     render() {
         const {
             width, height, layout, data, associateData, offset, cohortIndex,
-            selectedPathways, hoveredPathways, colorSettings, highlightedGene
+            selectedPathways, hoveredPathways, colorSettings, highlightedGene,
+            viewType
         } = this.props;
 
         return (
@@ -140,6 +141,7 @@ class PathwayScoresView extends PureComponent {
                     selectedPathways={selectedPathways}
                     associateData={associateData}
                     cohortIndex={cohortIndex}
+                    viewType={viewType}
                 />
                 <LabelWrapper
                     width={width}

--- a/src/components/VerticalGeneSetScoresView.js
+++ b/src/components/VerticalGeneSetScoresView.js
@@ -121,13 +121,6 @@ export default class VerticalGeneSetScoresView extends PureComponent {
                     onHover={this.onHover}
                     onClick={this.onClick}
                     onMouseOut={this.onMouseOut}
-                    data={{
-                        expression,
-                        pathways: returnedValue.pathways,
-                        referencePathways,
-                        samples,
-                        sortedSamples: returnedValue.sortedSamples
-                    }}
                 />
             </div>
         )

--- a/src/components/VerticalGeneSetScoresView.js
+++ b/src/components/VerticalGeneSetScoresView.js
@@ -61,7 +61,8 @@ export default class VerticalGeneSetScoresView extends PureComponent {
     render() {
 
         let {data, cohortIndex, filter, labelHeight, width, selectedCohort} = this.props;
-        const {expression, pathways, samples, copyNumber, referencePathways} = data;
+        console.log('data',data)
+        const {expression, pathways, samples, copyNumber} = data;
         if (!data || !data.pathways) {
             return <div>Loading Cohort {cohortIndex === 0 ? LABEL_A : LABEL_B}</div>
         }

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -57,6 +57,7 @@ export default class XenaGeneSetApp extends PureComponent {
             // view: PATHWAYS_VIEW,
             showColorEditor: false,
             showReciprocalPathway: false,
+            showColorByType: false,
             pathwaySets: [
                 {
                     name: 'Default Pathway',
@@ -571,6 +572,12 @@ export default class XenaGeneSetApp extends PureComponent {
         })
     };
 
+    toggleShowColorByType = () => {
+        this.setState({
+            showColorByType: !this.state.showColorByType
+        })
+    };
+
     callDownload = (cohortIndex) => {
         this.refs['xena-go-app-' + cohortIndex].callDownload();
     };
@@ -599,7 +606,9 @@ export default class XenaGeneSetApp extends PureComponent {
                                acceptGeneHandler={this.acceptGeneHandler}
                                downloadRawHandler={this.callDownload}
                                toggleShowReciprocalPathway={this.toggleShowReciprocalPathway}
+                               toggleShowColorByType={this.toggleShowColorByType}
                                showReciprocalPathway={this.state.showReciprocalPathway}
+                               showColorByType={this.state.showColorByType}
                 />
 
                 {this.state.view === XENA_VIEW && this.state.apps &&
@@ -709,6 +718,7 @@ export default class XenaGeneSetApp extends PureComponent {
                                               colorSettings={this.state.geneStateColors}
                                               setCollapsed={this.setCollapsed}
                                               collapsed={this.state.collapsed}
+                                              showColorByType={this.state.showColorByType}
                                 />
                                 <XenaGoViewer appData={this.state.apps[1]}
                                               pathwaySelect={this.pathwaySelect}
@@ -725,6 +735,7 @@ export default class XenaGeneSetApp extends PureComponent {
                                               colorSettings={this.state.geneStateColors}
                                               setCollapsed={this.setCollapsed}
                                               collapsed={this.state.collapsed}
+                                              showColorByType={this.state.showColorByType}
                                 />
                             </td>
                         </tr>

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -399,7 +399,6 @@ export default class XenaGeneSetApp extends PureComponent {
             filterMin
         };
         let prunedColumns = findPruneData(hashForPrune);
-        console.log('pruned data',prunedColumns)
         prunedColumns.samples = pathwayData.samples;
         return associatedData;
     }

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -13,7 +13,7 @@ import {addIndepProb, findAssociatedData, findPruneData} from '../functions/Data
 import FaArrowLeft from 'react-icons/lib/fa/arrow-left';
 import FaArrowRight from 'react-icons/lib/fa/arrow-right';
 import BaseStyle from '../css/base.css';
-import {sumInstances} from '../functions/util';
+import {sumInstances, sumTotals} from '../functions/util';
 import {LabelTop} from "./LabelTop";
 import VerticalGeneSetScoresView from "./VerticalGeneSetScoresView";
 import {izip, cycle} from 'itertools';
@@ -399,6 +399,7 @@ export default class XenaGeneSetApp extends PureComponent {
             filterMin
         };
         let prunedColumns = findPruneData(hashForPrune);
+        console.log('pruned data',prunedColumns)
         prunedColumns.samples = pathwayData.samples;
         return associatedData;
     }
@@ -411,7 +412,7 @@ export default class XenaGeneSetApp extends PureComponent {
 
     calculatePathwayScore(pathwayData, filter, min, cohortIndex) {
         return this.calculateAssociatedData(pathwayData, filter, min, cohortIndex).map(pathway => {
-            return sum(pathway);
+            return sumTotals(pathway);
         });
     }
 

--- a/src/components/XenaGoViewer.js
+++ b/src/components/XenaGoViewer.js
@@ -374,6 +374,7 @@ export default class XenaGoViewer extends PureComponent {
                                                    highlightedGene={this.props.highlightedGene}
                                                    onClick={this.clickPathway}
                                                    onHover={this.hoverGene}
+                                                   viewType={'COLOR_BY_TYPE'}
                                                    cohortIndex={this.state.key}
                                                    key={this.state.key}
                                                    shareGlobalGeneData={this.props.shareGlobalGeneData}

--- a/src/components/XenaGoViewer.js
+++ b/src/components/XenaGoViewer.js
@@ -313,7 +313,7 @@ export default class XenaGoViewer extends PureComponent {
         let cohortLoading = this.state.selectedCohort !== this.state.pathwayData.cohort;
         let geneList = this.getGenesForPathways(this.props.pathways);
 
-        let {renderHeight, renderOffset, cohortIndex, colorSettings} = this.props;
+        let {renderHeight, renderOffset, cohortIndex} = this.props;
 
         if (this.state.loadState === 'loaded') {
             if (this.state.selectedPathways.length > 0) {

--- a/src/components/XenaGoViewer.js
+++ b/src/components/XenaGoViewer.js
@@ -26,6 +26,7 @@ import {LABEL_A, LABEL_B, MAX_GENE_WIDTH, MIN_FILTER} from "./XenaGeneSetApp";
 import Button from "react-toolbox/lib/button";
 import FaDownload from 'react-icons/lib/fa/download';
 import defaultDatasetForGeneset from "../data/defaultDatasetForGeneset";
+import {COLOR_BY_TYPE, VIEW_TYPE} from "../functions/DrawFunctions";
 
 
 function lowerCaseCompareName(a, b) {
@@ -322,7 +323,8 @@ export default class XenaGoViewer extends PureComponent {
                         <tbody>
                         <tr>
                             {this.state.geneData && this.state.geneData.expression.rows && this.state.geneData.expression.rows.length > 0 &&
-                            <td valign="top" style={{paddingRight: 20, paddingLeft: 20,paddingTop: 0, paddingBottom: 0}}>
+                            <td valign="top"
+                                style={{paddingRight: 20, paddingLeft: 20, paddingTop: 0, paddingBottom: 0}}>
                                 <Card style={{height: 300, width: style.gene.columnWidth, marginTop: 5}}>
                                     <CohortSelector cohorts={this.state.cohortData}
                                                     selectedCohort={this.state.selectedCohort}
@@ -374,12 +376,12 @@ export default class XenaGoViewer extends PureComponent {
                                                    highlightedGene={this.props.highlightedGene}
                                                    onClick={this.clickPathway}
                                                    onHover={this.hoverGene}
-                                                   viewType={'COLOR_BY_TYPE'}
                                                    cohortIndex={this.state.key}
                                                    key={this.state.key}
                                                    shareGlobalGeneData={this.props.shareGlobalGeneData}
                                                    colorSettings={this.props.colorSettings}
                                                    collapsed={this.props.collapsed}
+                                                   viewType={this.props.showColorByType ? COLOR_BY_TYPE : 'total'}
                                 />
                             </td>
                             }
@@ -416,4 +418,5 @@ XenaGoViewer.propTypes = {
     highlightedGene: PropTypes.any, // optional
     setCollapsed: PropTypes.any,
     collapsed: PropTypes.any,
+    showColorByType: PropTypes.any,
 };

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -42,9 +42,13 @@ body {
     padding-left: 15px;
 }
 
-.highlightChip{
-    /*background-color: red;*/
+.mutationColor{
     color: firebrick;
+    font-weight: bolder;
+}
+
+.cnvColor{
+    color: cornflowerblue;
     font-weight: bolder;
 }
 

--- a/src/functions/ColorFunctions.js
+++ b/src/functions/ColorFunctions.js
@@ -10,13 +10,21 @@ export function getWhiteColor() {
     return '#F7FFF7';
 }
 
-export function getDarkColor() {
-    return '#1A535C';
+export function getCNVColorMask() {
+    // return '#1A535C';
+    return [0, 0, 200];
+}
+
+export function getMutationColorMask() {
+    // return '#DD55DD';
+    return [250, 0, 0];
+    // return [26, 83, 92];
 }
 
 export function getGeneColorMask() {
     return [26, 83, 92];
 }
+
 
 export function getGeneSetColorMask() {
     return [255, 10, 10];

--- a/src/functions/DataFunctions.js
+++ b/src/functions/DataFunctions.js
@@ -49,7 +49,7 @@ export function findAssociatedData(inputHash) {
     let {expression, copyNumber, geneList, pathways, samples, filter, min, selectedCohort} = inputHash;
     let key = JSON.stringify(inputHash);
     let data = associateCache.get(key);
-    if (!data) {
+    if (true || !data) {
         data = associateData(expression, copyNumber, geneList, pathways, samples, filter, min, selectedCohort);
         associateCache.set(key,data);
     }

--- a/src/functions/DataFunctions.js
+++ b/src/functions/DataFunctions.js
@@ -30,7 +30,8 @@ export let getGenePathwayLookup = pathways => {
 };
 
 export function pruneColumns(data, pathways, min) {
-    let columnScores = data.map(sum);
+    // TODO: we need to map the sum off each column
+    let columnScores = data.map( d => sum(d.total));
 
     let prunedPathways = pathways.filter((el, i) => columnScores[i] >= min);
     let prunedAssociations = data.filter((el, i) => columnScores[i] >= min);

--- a/src/functions/DataFunctions.js
+++ b/src/functions/DataFunctions.js
@@ -81,10 +81,12 @@ export function findPruneData(inputHash) {
  */
 export function associateData(expression, copyNumber, geneList, pathways, samples, filter, min, selectedCohort) {
     filter = filter.indexOf('All') === 0 ? '' : filter;
-    // let returnArray = times(pathways.length, () => times(samples.length, () => 0));
+    console.log('A:',times(pathways.length, () => times(samples.length, () => 0)));
     let returnArray = new Array(pathways.length).fill(0).map(() => new Array(samples.length).fill({total:0,mutation:0,cnv:0}));
-    console.log('returnarray',returnArray)
-    // console.log('matrix',matrix)
+    console.log('B:',returnArray)
+    // // console.log('matrix',matrix)
+    // let returnArray = JSON.parse(JSON.stringify(outputArray));
+    // console.log('C:',returnArray)
     let sampleIndex = new Map(samples.map((v, i) => [v, i]));
     let genePathwayLookup = getGenePathwayLookup(pathways);
 

--- a/src/functions/DataFunctions.js
+++ b/src/functions/DataFunctions.js
@@ -48,7 +48,7 @@ export function findAssociatedData(inputHash) {
     let key = JSON.stringify(inputHash);
     let data = associateCache.get(key);
     if (!data) {
-        data = associateData(expression, copyNumber, geneList, pathways, samples, filter, min, selectedCohort)
+        data = associateData(expression, copyNumber, geneList, pathways, samples, filter, min, selectedCohort);
         associateCache.set(key,data);
     }
 
@@ -66,6 +66,11 @@ export function findPruneData(inputHash) {
     return data;
 }
 
+export function createEmptyArray(pathwayLength,sampleLength){
+    let defaultValue = {total:0,mutation:0,cnv:0};
+    return Array(pathwayLength).fill(Array(sampleLength).fill(defaultValue));
+}
+
 /**
  * For each expression result, for each gene listed, for each column represented in the pathways, populate the appropriate samples
  *
@@ -81,12 +86,8 @@ export function findPruneData(inputHash) {
  */
 export function associateData(expression, copyNumber, geneList, pathways, samples, filter, min, selectedCohort) {
     filter = filter.indexOf('All') === 0 ? '' : filter;
-    console.log('A:',times(pathways.length, () => times(samples.length, () => 0)));
-    let returnArray = new Array(pathways.length).fill(0).map(() => new Array(samples.length).fill({total:0,mutation:0,cnv:0}));
+    let returnArray = createEmptyArray(pathways.length,samples.length)
     console.log('B:',returnArray)
-    // // console.log('matrix',matrix)
-    // let returnArray = JSON.parse(JSON.stringify(outputArray));
-    // console.log('C:',returnArray)
     let sampleIndex = new Map(samples.map((v, i) => [v, i]));
     let genePathwayLookup = getGenePathwayLookup(pathways);
 

--- a/src/functions/DataFunctions.js
+++ b/src/functions/DataFunctions.js
@@ -69,8 +69,7 @@ export function findPruneData(inputHash) {
 }
 
 export function createEmptyArray(pathwayLength,sampleLength){
-    // return times(pathwayLength, () => times(sampleLength, () => JSON.parse(JSON.stringify(DEFAULT_DATA_VALUE))));
-    return times(pathwayLength, () => times(sampleLength, () => JSON.stringify(DEFAULT_DATA_VALUE)));
+    return times(pathwayLength, () => times(sampleLength, () => JSON.parse(JSON.stringify(DEFAULT_DATA_VALUE))));
 }
 
 /**
@@ -89,7 +88,6 @@ export function createEmptyArray(pathwayLength,sampleLength){
 export function associateData(expression, copyNumber, geneList, pathways, samples, filter, min, selectedCohort) {
     filter = filter.indexOf('All') === 0 ? '' : filter;
     let returnArray = createEmptyArray(pathways.length,samples.length)
-    console.log('B:',returnArray)
     let sampleIndex = new Map(samples.map((v, i) => [v, i]));
     let genePathwayLookup = getGenePathwayLookup(pathways);
 

--- a/src/functions/DataFunctions.js
+++ b/src/functions/DataFunctions.js
@@ -7,6 +7,8 @@ import lru from 'tiny-lru/lib/tiny-lru.es5'
 let associateCache = lru(500);
 let pruneDataCache = lru(500);
 
+export const DEFAULT_DATA_VALUE = {total:0,mutation:0,cnv:0};
+
 export function getCopyNumberValue(copyNumberValue, amplificationThreshold, deletionThreshold) {
     return (!isNaN(copyNumberValue) && (copyNumberValue >= amplificationThreshold || copyNumberValue <= deletionThreshold)) ? 1 : 0;
 }
@@ -67,8 +69,8 @@ export function findPruneData(inputHash) {
 }
 
 export function createEmptyArray(pathwayLength,sampleLength){
-    let defaultValue = {total:0,mutation:0,cnv:0};
-    return Array(pathwayLength).fill(Array(sampleLength).fill(defaultValue));
+    // return times(pathwayLength, () => times(sampleLength, () => JSON.parse(JSON.stringify(DEFAULT_DATA_VALUE))));
+    return times(pathwayLength, () => times(sampleLength, () => JSON.stringify(DEFAULT_DATA_VALUE)));
 }
 
 /**

--- a/src/functions/DataFunctions.js
+++ b/src/functions/DataFunctions.js
@@ -8,8 +8,8 @@ let associateCache = lru(500);
 let pruneDataCache = lru(500);
 
 // export const DEFAULT_DATA_HEADER= ['total','mutation','cnv'];
-export const DEFAULT_DATA_ARRAY= [0,0,0];
-export const DEFAULT_DATA_ARRAY_HEADERS = {total:0,mutation:1,cnv:2};
+// export const DEFAULT_DATA_ARRAY= [0,0,0];
+// export const DEFAULT_DATA_ARRAY_HEADERS = {total:0,mutation:1,cnv:2};
 
 export function getCopyNumberValue(copyNumberValue, amplificationThreshold, deletionThreshold) {
     return (!isNaN(copyNumberValue) && (copyNumberValue >= amplificationThreshold || copyNumberValue <= deletionThreshold)) ? 1 : 0;
@@ -71,12 +71,8 @@ export function findPruneData(inputHash) {
 }
 
 export function createEmptyArray(pathwayLength,sampleLength){
-    // return times(pathwayLength, () => times(sampleLength, () => JSON.parse(JSON.stringify(DEFAULT_DATA_VALUE))));
-    // return times(pathwayLength, () => times(sampleLength, () => DEFAULT_DATA_VALUE));
-    return times(pathwayLength, () => times(sampleLength, () => JSON.parse(JSON.stringify(DEFAULT_DATA_ARRAY))));
-    // return times(pathwayLength, () => times(sampleLength, () => JSON.parse(JSON.stringify(DEFAULT_DATA_VALUE))));
+    return times(pathwayLength, () => times(sampleLength, () => 0));
 }
-
 
 /**
  * For each expression result, for each gene listed, for each column represented in the pathways, populate the appropriate samples
@@ -93,8 +89,12 @@ export function createEmptyArray(pathwayLength,sampleLength){
  */
 export function associateData(expression, copyNumber, geneList, pathways, samples, filter, min, selectedCohort) {
     filter = filter.indexOf('All') === 0 ? '' : filter;
-    let returnArray = createEmptyArray(pathways.length,samples.length)
-    console.log('B:',returnArray)
+    // let cnvArray = createEmptyArray(pathways.length,samples.length)
+    let cnvArray = times(pathways.length, () => times(samples.length, () => 0));
+    // let mutationArray = createEmptyArray(pathways.length,samples.length)
+    let mutationArray = times(pathways.length, () => times(samples.length, () => 0));
+    console.log('B:',cnvArray)
+    console.log('C:',mutationArray)
     let sampleIndex = new Map(samples.map((v, i) => [v, i]));
     let genePathwayLookup = getGenePathwayLookup(pathways);
 
@@ -106,8 +106,8 @@ export function associateData(expression, copyNumber, geneList, pathways, sample
             let pathwayIndices = genePathwayLookup(row.gene);
 
             for (let index of pathwayIndices) {
-                returnArray[index][sampleIndex.get(row.sample)][DEFAULT_DATA_ARRAY_HEADERS.total] += effectValue;
-                returnArray[index][sampleIndex.get(row.sample)][DEFAULT_DATA_ARRAY_HEADERS.mutation] += effectValue;
+                mutationArray[index][sampleIndex.get(row.sample)] += effectValue;
+                mutationArray[index][sampleIndex.get(row.sample)] += effectValue;
             }
         }
     }
@@ -132,8 +132,8 @@ export function associateData(expression, copyNumber, geneList, pathways, sample
                         , selectedCohort ? selectedCohort.amplificationThreshold : 2
                         , selectedCohort ? selectedCohort.deletionThreshold : -2);
                     if (returnValue > 0) {
-                        returnArray[index][sampleEntryIndex][DEFAULT_DATA_ARRAY_HEADERS.total] += returnValue;
-                        returnArray[index][sampleEntryIndex][DEFAULT_DATA_ARRAY_HEADERS.cnv] += returnValue;
+                        cnvArray[index][sampleEntryIndex] += returnValue;
+                        cnvArray[index][sampleEntryIndex] += returnValue;
                     }
                 }
             }
@@ -142,7 +142,7 @@ export function associateData(expression, copyNumber, geneList, pathways, sample
     }
 
 
-    return returnArray;
+    return mutationArray;
 
 }
 

--- a/src/functions/DataFunctions.js
+++ b/src/functions/DataFunctions.js
@@ -7,7 +7,9 @@ import lru from 'tiny-lru/lib/tiny-lru.es5'
 let associateCache = lru(500);
 let pruneDataCache = lru(500);
 
-export const DEFAULT_DATA_VALUE = {total:0,mutation:0,cnv:0};
+// export const DEFAULT_DATA_HEADER= ['total','mutation','cnv'];
+export const DEFAULT_DATA_ARRAY= [0,0,0];
+export const DEFAULT_DATA_ARRAY_HEADERS = {total:0,mutation:1,cnv:2};
 
 export function getCopyNumberValue(copyNumberValue, amplificationThreshold, deletionThreshold) {
     return (!isNaN(copyNumberValue) && (copyNumberValue >= amplificationThreshold || copyNumberValue <= deletionThreshold)) ? 1 : 0;
@@ -70,8 +72,11 @@ export function findPruneData(inputHash) {
 
 export function createEmptyArray(pathwayLength,sampleLength){
     // return times(pathwayLength, () => times(sampleLength, () => JSON.parse(JSON.stringify(DEFAULT_DATA_VALUE))));
-    return times(pathwayLength, () => times(sampleLength, () => JSON.stringify(DEFAULT_DATA_VALUE)));
+    // return times(pathwayLength, () => times(sampleLength, () => DEFAULT_DATA_VALUE));
+    return times(pathwayLength, () => times(sampleLength, () => JSON.parse(JSON.stringify(DEFAULT_DATA_ARRAY))));
+    // return times(pathwayLength, () => times(sampleLength, () => JSON.parse(JSON.stringify(DEFAULT_DATA_VALUE))));
 }
+
 
 /**
  * For each expression result, for each gene listed, for each column represented in the pathways, populate the appropriate samples
@@ -101,8 +106,8 @@ export function associateData(expression, copyNumber, geneList, pathways, sample
             let pathwayIndices = genePathwayLookup(row.gene);
 
             for (let index of pathwayIndices) {
-                returnArray[index][sampleIndex.get(row.sample)].total += effectValue;
-                returnArray[index][sampleIndex.get(row.sample)].mutation += effectValue;
+                returnArray[index][sampleIndex.get(row.sample)][DEFAULT_DATA_ARRAY_HEADERS.total] += effectValue;
+                returnArray[index][sampleIndex.get(row.sample)][DEFAULT_DATA_ARRAY_HEADERS.mutation] += effectValue;
             }
         }
     }
@@ -127,8 +132,8 @@ export function associateData(expression, copyNumber, geneList, pathways, sample
                         , selectedCohort ? selectedCohort.amplificationThreshold : 2
                         , selectedCohort ? selectedCohort.deletionThreshold : -2);
                     if (returnValue > 0) {
-                        returnArray[index][sampleEntryIndex].total += returnValue;
-                        returnArray[index][sampleEntryIndex].cnv += returnValue;
+                        returnArray[index][sampleEntryIndex][DEFAULT_DATA_ARRAY_HEADERS.total] += returnValue;
+                        returnArray[index][sampleEntryIndex][DEFAULT_DATA_ARRAY_HEADERS.cnv] += returnValue;
                     }
                 }
             }

--- a/src/functions/DataFunctions.js
+++ b/src/functions/DataFunctions.js
@@ -80,7 +80,10 @@ export function findPruneData(inputHash) {
  */
 export function associateData(expression, copyNumber, geneList, pathways, samples, filter, min, selectedCohort) {
     filter = filter.indexOf('All') === 0 ? '' : filter;
-    let returnArray = times(pathways.length, () => times(samples.length, () => 0));
+    // let returnArray = times(pathways.length, () => times(samples.length, () => 0));
+    let returnArray = new Array(pathways.length).fill(0).map(() => new Array(samples.length).fill({total:0,mutation:0,cnv:0}));
+    console.log('returnarray',returnArray)
+    // console.log('matrix',matrix)
     let sampleIndex = new Map(samples.map((v, i) => [v, i]));
     let genePathwayLookup = getGenePathwayLookup(pathways);
 
@@ -92,7 +95,8 @@ export function associateData(expression, copyNumber, geneList, pathways, sample
             let pathwayIndices = genePathwayLookup(row.gene);
 
             for (let index of pathwayIndices) {
-                returnArray[index][sampleIndex.get(row.sample)] += effectValue;
+                returnArray[index][sampleIndex.get(row.sample)].total += effectValue;
+                returnArray[index][sampleIndex.get(row.sample)].mutation += effectValue;
             }
         }
     }
@@ -117,7 +121,8 @@ export function associateData(expression, copyNumber, geneList, pathways, sample
                         , selectedCohort ? selectedCohort.amplificationThreshold : 2
                         , selectedCohort ? selectedCohort.deletionThreshold : -2);
                     if (returnValue > 0) {
-                        returnArray[index][sampleEntryIndex] += returnValue;
+                        returnArray[index][sampleEntryIndex].total += returnValue;
+                        returnArray[index][sampleEntryIndex].cnv += returnValue;
                     }
                 }
             }

--- a/src/functions/DataFunctions.js
+++ b/src/functions/DataFunctions.js
@@ -7,9 +7,7 @@ import lru from 'tiny-lru/lib/tiny-lru.es5'
 let associateCache = lru(500);
 let pruneDataCache = lru(500);
 
-// export const DEFAULT_DATA_HEADER= ['total','mutation','cnv'];
-export const DEFAULT_DATA_ARRAY= [0,0,0];
-export const DEFAULT_DATA_ARRAY_HEADERS = {total:0,mutation:1,cnv:2};
+export const DEFAULT_DATA_VALUE = {total:0,mutation:0,cnv:0};
 
 export function getCopyNumberValue(copyNumberValue, amplificationThreshold, deletionThreshold) {
     return (!isNaN(copyNumberValue) && (copyNumberValue >= amplificationThreshold || copyNumberValue <= deletionThreshold)) ? 1 : 0;
@@ -72,11 +70,8 @@ export function findPruneData(inputHash) {
 
 export function createEmptyArray(pathwayLength,sampleLength){
     // return times(pathwayLength, () => times(sampleLength, () => JSON.parse(JSON.stringify(DEFAULT_DATA_VALUE))));
-    // return times(pathwayLength, () => times(sampleLength, () => DEFAULT_DATA_VALUE));
-    return times(pathwayLength, () => times(sampleLength, () => JSON.parse(JSON.stringify(DEFAULT_DATA_ARRAY))));
-    // return times(pathwayLength, () => times(sampleLength, () => JSON.parse(JSON.stringify(DEFAULT_DATA_VALUE))));
+    return times(pathwayLength, () => times(sampleLength, () => JSON.stringify(DEFAULT_DATA_VALUE)));
 }
-
 
 /**
  * For each expression result, for each gene listed, for each column represented in the pathways, populate the appropriate samples
@@ -106,8 +101,8 @@ export function associateData(expression, copyNumber, geneList, pathways, sample
             let pathwayIndices = genePathwayLookup(row.gene);
 
             for (let index of pathwayIndices) {
-                returnArray[index][sampleIndex.get(row.sample)][DEFAULT_DATA_ARRAY_HEADERS.total] += effectValue;
-                returnArray[index][sampleIndex.get(row.sample)][DEFAULT_DATA_ARRAY_HEADERS.mutation] += effectValue;
+                returnArray[index][sampleIndex.get(row.sample)].total += effectValue;
+                returnArray[index][sampleIndex.get(row.sample)].mutation += effectValue;
             }
         }
     }
@@ -132,8 +127,8 @@ export function associateData(expression, copyNumber, geneList, pathways, sample
                         , selectedCohort ? selectedCohort.amplificationThreshold : 2
                         , selectedCohort ? selectedCohort.deletionThreshold : -2);
                     if (returnValue > 0) {
-                        returnArray[index][sampleEntryIndex][DEFAULT_DATA_ARRAY_HEADERS.total] += returnValue;
-                        returnArray[index][sampleEntryIndex][DEFAULT_DATA_ARRAY_HEADERS.cnv] += returnValue;
+                        returnArray[index][sampleEntryIndex].total += returnValue;
+                        returnArray[index][sampleEntryIndex].cnv += returnValue;
                     }
                 }
             }

--- a/src/functions/DataFunctions.js
+++ b/src/functions/DataFunctions.js
@@ -8,8 +8,8 @@ let associateCache = lru(500);
 let pruneDataCache = lru(500);
 
 // export const DEFAULT_DATA_HEADER= ['total','mutation','cnv'];
-// export const DEFAULT_DATA_ARRAY= [0,0,0];
-// export const DEFAULT_DATA_ARRAY_HEADERS = {total:0,mutation:1,cnv:2};
+export const DEFAULT_DATA_ARRAY= [0,0,0];
+export const DEFAULT_DATA_ARRAY_HEADERS = {total:0,mutation:1,cnv:2};
 
 export function getCopyNumberValue(copyNumberValue, amplificationThreshold, deletionThreshold) {
     return (!isNaN(copyNumberValue) && (copyNumberValue >= amplificationThreshold || copyNumberValue <= deletionThreshold)) ? 1 : 0;
@@ -71,8 +71,12 @@ export function findPruneData(inputHash) {
 }
 
 export function createEmptyArray(pathwayLength,sampleLength){
-    return times(pathwayLength, () => times(sampleLength, () => 0));
+    // return times(pathwayLength, () => times(sampleLength, () => JSON.parse(JSON.stringify(DEFAULT_DATA_VALUE))));
+    // return times(pathwayLength, () => times(sampleLength, () => DEFAULT_DATA_VALUE));
+    return times(pathwayLength, () => times(sampleLength, () => JSON.parse(JSON.stringify(DEFAULT_DATA_ARRAY))));
+    // return times(pathwayLength, () => times(sampleLength, () => JSON.parse(JSON.stringify(DEFAULT_DATA_VALUE))));
 }
+
 
 /**
  * For each expression result, for each gene listed, for each column represented in the pathways, populate the appropriate samples
@@ -89,12 +93,8 @@ export function createEmptyArray(pathwayLength,sampleLength){
  */
 export function associateData(expression, copyNumber, geneList, pathways, samples, filter, min, selectedCohort) {
     filter = filter.indexOf('All') === 0 ? '' : filter;
-    // let cnvArray = createEmptyArray(pathways.length,samples.length)
-    let cnvArray = times(pathways.length, () => times(samples.length, () => 0));
-    // let mutationArray = createEmptyArray(pathways.length,samples.length)
-    let mutationArray = times(pathways.length, () => times(samples.length, () => 0));
-    console.log('B:',cnvArray)
-    console.log('C:',mutationArray)
+    let returnArray = createEmptyArray(pathways.length,samples.length)
+    console.log('B:',returnArray)
     let sampleIndex = new Map(samples.map((v, i) => [v, i]));
     let genePathwayLookup = getGenePathwayLookup(pathways);
 
@@ -106,8 +106,8 @@ export function associateData(expression, copyNumber, geneList, pathways, sample
             let pathwayIndices = genePathwayLookup(row.gene);
 
             for (let index of pathwayIndices) {
-                mutationArray[index][sampleIndex.get(row.sample)] += effectValue;
-                mutationArray[index][sampleIndex.get(row.sample)] += effectValue;
+                returnArray[index][sampleIndex.get(row.sample)][DEFAULT_DATA_ARRAY_HEADERS.total] += effectValue;
+                returnArray[index][sampleIndex.get(row.sample)][DEFAULT_DATA_ARRAY_HEADERS.mutation] += effectValue;
             }
         }
     }
@@ -132,8 +132,8 @@ export function associateData(expression, copyNumber, geneList, pathways, sample
                         , selectedCohort ? selectedCohort.amplificationThreshold : 2
                         , selectedCohort ? selectedCohort.deletionThreshold : -2);
                     if (returnValue > 0) {
-                        cnvArray[index][sampleEntryIndex] += returnValue;
-                        cnvArray[index][sampleEntryIndex] += returnValue;
+                        returnArray[index][sampleEntryIndex][DEFAULT_DATA_ARRAY_HEADERS.total] += returnValue;
+                        returnArray[index][sampleEntryIndex][DEFAULT_DATA_ARRAY_HEADERS.cnv] += returnValue;
                     }
                 }
             }
@@ -142,7 +142,7 @@ export function associateData(expression, copyNumber, geneList, pathways, sample
     }
 
 
-    return mutationArray;
+    return returnArray;
 
 }
 

--- a/src/functions/DataFunctions.js
+++ b/src/functions/DataFunctions.js
@@ -8,7 +8,7 @@ let associateCache = lru(500);
 let pruneDataCache = lru(500);
 
 // NOTE: this should be false for production.
-let ignoreCache = true ;
+let ignoreCache = false;
 
 export const DEFAULT_DATA_VALUE = {total:0,mutation:0,cnv:0};
 

--- a/src/functions/DataFunctions.js
+++ b/src/functions/DataFunctions.js
@@ -7,6 +7,9 @@ import lru from 'tiny-lru/lib/tiny-lru.es5'
 let associateCache = lru(500);
 let pruneDataCache = lru(500);
 
+// NOTE: this should be false for production.
+let ignoreCache = true ;
+
 export const DEFAULT_DATA_VALUE = {total:0,mutation:0,cnv:0};
 
 export function getCopyNumberValue(copyNumberValue, amplificationThreshold, deletionThreshold) {
@@ -49,7 +52,7 @@ export function findAssociatedData(inputHash) {
     let {expression, copyNumber, geneList, pathways, samples, filter, min, selectedCohort} = inputHash;
     let key = JSON.stringify(inputHash);
     let data = associateCache.get(key);
-    if (true || !data) {
+    if (ignoreCache || !data) {
         data = associateData(expression, copyNumber, geneList, pathways, samples, filter, min, selectedCohort);
         associateCache.set(key,data);
     }
@@ -61,7 +64,7 @@ export function findPruneData(inputHash) {
     let {associatedData, pathways, filterMin} = inputHash;
     let key = JSON.stringify(inputHash);
     let data = pruneDataCache.get(key);
-    if (!data) {
+    if (ignoreCache || !data) {
         data = pruneColumns(associatedData, pathways, filterMin);
         pruneDataCache.set(key,data);
     }

--- a/src/functions/DrawFunctions.js
+++ b/src/functions/DrawFunctions.js
@@ -28,16 +28,14 @@ function findRegions(height, count) {
 }
 
 function regionColor(data) {
-    let total = sumTotal(data);
+    let total = data.reduce(sumDataTotal);
     let p = total / data.length;
     let scale = 5;
     return 255 * p / scale;
 }
 
-function sumTotal(inputArray){
-    let total = 0 ;
-    inputArray.forEach( i => total += i.total);
-    return total ;
+export function sumDataTotal(total,data){
+    return total + data.total;
 }
 
 

--- a/src/functions/DrawFunctions.js
+++ b/src/functions/DrawFunctions.js
@@ -1,7 +1,7 @@
 import {sumTotals, reduceByKey, map2, /*partition, */partitionN} from './util';
 import {range} from 'underscore';
 import React from "react";
-import {getGeneColorMask, getGeneSetColorMask} from '../functions/ColorFunctions'
+import {getCNVColorMask, getGeneColorMask, getGeneSetColorMask, getMutationColorMask} from '../functions/ColorFunctions'
 import {GENE_LABEL_HEIGHT} from "../components/PathwayScoresView";
 
 function clearScreen(vg, width, height) {
@@ -27,20 +27,19 @@ function findRegions(height, count) {
     return regions;
 }
 
-var colorCount = 0 ;
-
-function regionColor(data) {
+function regionColor(data, type) {
     // let total = data.reduce(sumDataTotal(0));
-    let total = sumDataTotalSimple(data);
+    let total = sumDataTotalSimple(data, type);
+    if(total===0) return 0 ;
     let p = total / data.length;
     let scale = 5;
     return 255 * p / scale;
 }
 
-export function sumDataTotalSimple(data){
-    let total = 0 ;
-    data.forEach(d => total += d.total);
-    return total ;
+export function sumDataTotalSimple(data, type) {
+    let total = 0;
+    data.forEach(d => total += d[type]);
+    return total;
 }
 
 
@@ -50,7 +49,7 @@ function drawGeneDataTotal(ctx, width, totalHeight, layout, data, labelHeight, c
     let regions = findRegions(height, tissueCount);
     let img = ctx.createImageData(width, totalHeight);
 
-    let offsetHeight = cohortIndex === 0 ? 0 : labelHeight - 11 ;
+    let offsetHeight = cohortIndex === 0 ? 0 : labelHeight - 11;
 
     // for each row / geneSet
     layout.forEach(function (el, i) {
@@ -66,7 +65,7 @@ function drawGeneDataTotal(ctx, width, totalHeight, layout, data, labelHeight, c
             let r = regions.get(rs);
             let d = rowData.slice(r.start, r.end + 1);
 
-            let color = regionColor(d);
+            let color = regionColor(d, 'total');
 
 
             for (let y = rs + offsetHeight; y < rs + r.height + offsetHeight; ++y) {
@@ -81,6 +80,67 @@ function drawGeneDataTotal(ctx, width, totalHeight, layout, data, labelHeight, c
                     img.data[l + 1] = colorMask[1];
                     img.data[l + 2] = colorMask[2];
                     img.data[l + 3] = color;
+                }
+            }
+        }
+
+        ctx.putImageData(img, 0, 0);
+    });
+}
+
+function drawGeneWithColorType(ctx, width, totalHeight, layout, data, labelHeight, cohortIndex) {
+    let height = totalHeight - labelHeight;
+    let tissueCount = data[0].length;
+    let regions = findRegions(height, tissueCount);
+    let img = ctx.createImageData(width, totalHeight);
+
+    let cnvColorMask = getCNVColorMask();
+    let mutationColorMask = getMutationColorMask();
+
+    let offsetHeight = cohortIndex === 0 ? 0 : labelHeight - 11;
+
+    // for each row / geneSet
+    layout.forEach(function (el, i) {
+        // TODO: may be faster to transform the whole data cohort at once
+        let rowData = data[i];
+        if (cohortIndex === 0) {
+            rowData = data[i].reverse();
+        }
+
+        // let reverseMap = new Map(Array.from(regions).reverse());
+        // XXX watch for poor iterator performance in this for...of.
+        for (let rs of regions.keys()) {
+            let r = regions.get(rs);
+            let d = rowData.slice(r.start, r.end + 1);
+
+            let mutationColor = regionColor(d, 'mutation');
+            let cnvColor = regionColor(d, 'cnv');
+            let totalColor = regionColor(d, 'total');
+            // if (mutationColor !== cnvColor) {
+            //     console.log('A', d, cnvColor, mutationColor, totalColor)
+            // }
+
+
+            for (let y = rs + offsetHeight; y < rs + r.height + offsetHeight; ++y) {
+                let pxRow = y * width,
+                    buffStart = (pxRow + el.start) * 4,
+                    buffEnd = (pxRow + el.start + el.size) * 4,
+                    buffMid = (buffEnd - buffStart) / 2 + buffStart;
+                // if (buffStart < 20000 && cnvColor !== mutationColor) {
+                //     console.log('expression 2 bit', buffStart, buffMid, buffEnd, el, rs, r, pxRow, y, width, d, cnvColor, mutationColor)
+                // }
+
+                for (let l = buffStart; l < buffMid; l += 4) {
+                    img.data[l] = cnvColorMask[0];
+                    img.data[l + 1] = cnvColorMask[1];
+                    img.data[l + 2] = cnvColorMask[2];
+                    img.data[l + 3] = cnvColor;
+                }
+                for (let l = buffMid; l < buffEnd; l += 4) {
+                    img.data[l] = mutationColorMask[0];
+                    img.data[l + 1] = mutationColorMask[1];
+                    img.data[l + 2] = mutationColorMask[2];
+                    img.data[l + 3] = mutationColor;
                 }
             }
         }
@@ -137,7 +197,7 @@ function drawGeneSetData(ctx, width, totalHeight, layout, data, labelHeight, col
             let pxRow = el.start * 4 * img.width; // first column and row in the block
 
             // start buffer at the correct column
-            for(let xPos = 0 ; xPos < r.width ; ++xPos){
+            for (let xPos = 0; xPos < r.width; ++xPos) {
                 let buffStart = pxRow + (xPos + r.x) * 4;
                 let buffEnd = buffStart + (r.x + xPos + img.width * 4 * labelHeight);
 
@@ -165,7 +225,8 @@ export default {
         if (associateData.length === 0) {
             return;
         }
-        drawGeneDataTotal(vg, width, height, layout, associateData, GENE_LABEL_HEIGHT, getGeneColorMask(), cohortIndex);
+        drawGeneWithColorType(vg, width, height, layout, associateData, GENE_LABEL_HEIGHT, cohortIndex);
+        // drawGeneDataTotal(vg, width, height, layout, associateData, GENE_LABEL_HEIGHT, getGeneColorMask(), cohortIndex);
 
     },
 

--- a/src/functions/DrawFunctions.js
+++ b/src/functions/DrawFunctions.js
@@ -115,10 +115,7 @@ function drawGeneWithColorType(ctx, width, totalHeight, layout, data, labelHeigh
 
             let mutationColor = regionColor(d, 'mutation');
             let cnvColor = regionColor(d, 'cnv');
-            let totalColor = regionColor(d, 'total');
-            // if (mutationColor !== cnvColor) {
-            //     console.log('A', d, cnvColor, mutationColor, totalColor)
-            // }
+            // let totalColor = regionColor(d, 'total');
 
 
             for (let y = rs + offsetHeight; y < rs + r.height + offsetHeight; ++y) {
@@ -126,10 +123,6 @@ function drawGeneWithColorType(ctx, width, totalHeight, layout, data, labelHeigh
                     buffStart = (pxRow + el.start) * 4,
                     buffEnd = (pxRow + el.start + el.size) * 4,
                     buffMid = (buffEnd - buffStart) / 2 + buffStart;
-                // if (buffStart < 20000 && cnvColor !== mutationColor) {
-                //     console.log('expression 2 bit', buffStart, buffMid, buffEnd, el, rs, r, pxRow, y, width, d, cnvColor, mutationColor)
-                // }
-
                 for (let l = buffStart; l < buffMid; l += 4) {
                     img.data[l] = cnvColorMask[0];
                     img.data[l + 1] = cnvColorMask[1];
@@ -218,15 +211,20 @@ export default {
 
 
     drawGeneView(vg, props) {
-        let {width, height, layout, cohortIndex, associateData} = props;
+        let {width, height, layout, cohortIndex, associateData,viewType} = props;
 
         clearScreen(vg, width, height);
 
         if (associateData.length === 0) {
             return;
         }
-        drawGeneWithColorType(vg, width, height, layout, associateData, GENE_LABEL_HEIGHT, cohortIndex);
-        // drawGeneDataTotal(vg, width, height, layout, associateData, GENE_LABEL_HEIGHT, getGeneColorMask(), cohortIndex);
+
+        // drawGeneWithColorType(vg, width, height, layout, associateData, GENE_LABEL_HEIGHT, cohortIndex);
+        if(viewType && viewType==='COLOR_BY_TYPE'){
+            drawGeneWithColorType(vg, width, height, layout, associateData, GENE_LABEL_HEIGHT, cohortIndex);
+        }else{
+            drawGeneDataTotal(vg, width, height, layout, associateData, GENE_LABEL_HEIGHT, getGeneColorMask(), cohortIndex);
+        }
 
     },
 

--- a/src/functions/DrawFunctions.js
+++ b/src/functions/DrawFunctions.js
@@ -37,10 +37,6 @@ function regionColor(data) {
     return 255 * p / scale;
 }
 
-export function sumDataTotal(total,data){
-    return  data.total + total;
-}
-
 export function sumDataTotalSimple(data){
     let total = 0 ;
     data.forEach(d => total += d.total);
@@ -48,7 +44,7 @@ export function sumDataTotalSimple(data){
 }
 
 
-function drawExpressionData(ctx, width, totalHeight, layout, data, labelHeight, colorMask, cohortIndex) {
+function drawGeneDataTotal(ctx, width, totalHeight, layout, data, labelHeight, colorMask, cohortIndex) {
     let height = totalHeight - labelHeight;
     let tissueCount = data[0].length;
     let regions = findRegions(height, tissueCount);
@@ -169,7 +165,7 @@ export default {
         if (associateData.length === 0) {
             return;
         }
-        drawExpressionData(vg, width, height, layout, associateData, GENE_LABEL_HEIGHT, getGeneColorMask(), cohortIndex);
+        drawGeneDataTotal(vg, width, height, layout, associateData, GENE_LABEL_HEIGHT, getGeneColorMask(), cohortIndex);
 
     },
 

--- a/src/functions/DrawFunctions.js
+++ b/src/functions/DrawFunctions.js
@@ -1,4 +1,4 @@
-import {sum, reduceByKey, map2, /*partition, */partitionN} from './util';
+import {sumTotals, reduceByKey, map2, /*partition, */partitionN} from './util';
 import {range} from 'underscore';
 import React from "react";
 import {getGeneColorMask, getGeneSetColorMask} from '../functions/ColorFunctions'

--- a/src/functions/DrawFunctions.js
+++ b/src/functions/DrawFunctions.js
@@ -4,6 +4,8 @@ import React from "react";
 import {getCNVColorMask, getGeneColorMask, getGeneSetColorMask, getMutationColorMask} from '../functions/ColorFunctions'
 import {GENE_LABEL_HEIGHT} from "../components/PathwayScoresView";
 
+export const COLOR_BY_TYPE = 'COLOR_BY_TYPE';
+
 function clearScreen(vg, width, height) {
     vg.save();
     vg.fillStyle = '#FFFFFF'; // sets the color to fill in the rectangle with
@@ -30,7 +32,7 @@ function findRegions(height, count) {
 function regionColor(data, type) {
     // let total = data.reduce(sumDataTotal(0));
     let total = sumDataTotalSimple(data, type);
-    if(total===0) return 0 ;
+    if (total === 0) return 0;
     let p = total / data.length;
     let scale = 5;
     return 255 * p / scale;
@@ -211,7 +213,7 @@ export default {
 
 
     drawGeneView(vg, props) {
-        let {width, height, layout, cohortIndex, associateData,viewType} = props;
+        let {width, height, layout, cohortIndex, associateData, viewType} = props;
 
         clearScreen(vg, width, height);
 
@@ -220,9 +222,9 @@ export default {
         }
 
         // drawGeneWithColorType(vg, width, height, layout, associateData, GENE_LABEL_HEIGHT, cohortIndex);
-        if(viewType && viewType==='COLOR_BY_TYPE'){
+        if (viewType && viewType === COLOR_BY_TYPE) {
             drawGeneWithColorType(vg, width, height, layout, associateData, GENE_LABEL_HEIGHT, cohortIndex);
-        }else{
+        } else {
             drawGeneDataTotal(vg, width, height, layout, associateData, GENE_LABEL_HEIGHT, getGeneColorMask(), cohortIndex);
         }
 

--- a/src/functions/DrawFunctions.js
+++ b/src/functions/DrawFunctions.js
@@ -28,10 +28,18 @@ function findRegions(height, count) {
 }
 
 function regionColor(data) {
-    let p = sum(data) / data.length;
+    let total = sumTotal(data);
+    let p = total / data.length;
     let scale = 5;
     return 255 * p / scale;
 }
+
+function sumTotal(inputArray){
+    let total = 0 ;
+    inputArray.forEach( i => total += i.total);
+    return total ;
+}
+
 
 function drawExpressionData(ctx, width, totalHeight, layout, data, labelHeight, colorMask, cohortIndex) {
     let height = totalHeight - labelHeight;

--- a/src/functions/DrawFunctions.js
+++ b/src/functions/DrawFunctions.js
@@ -32,10 +32,6 @@ var colorCount = 0 ;
 function regionColor(data) {
     // let total = data.reduce(sumDataTotal(0));
     let total = sumDataTotalSimple(data);
-    if(colorCount<100){
-        console.log('total',total)
-        ++colorCount
-    }
     let p = total / data.length;
     let scale = 5;
     return 255 * p / scale;
@@ -76,9 +72,6 @@ function drawExpressionData(ctx, width, totalHeight, layout, data, labelHeight, 
 
             let color = regionColor(d);
 
-            if(colorCount<100){
-                console.log('color',color);
-            }
 
             for (let y = rs + offsetHeight; y < rs + r.height + offsetHeight; ++y) {
                 let pxRow = y * width,

--- a/src/functions/DrawFunctions.js
+++ b/src/functions/DrawFunctions.js
@@ -27,15 +27,28 @@ function findRegions(height, count) {
     return regions;
 }
 
+var colorCount = 0 ;
+
 function regionColor(data) {
-    let total = data.reduce(sumDataTotal);
+    // let total = data.reduce(sumDataTotal(0));
+    let total = sumDataTotalSimple(data);
+    if(colorCount<100){
+        console.log('total',total)
+        ++colorCount
+    }
     let p = total / data.length;
     let scale = 5;
     return 255 * p / scale;
 }
 
 export function sumDataTotal(total,data){
-    return total + data.total;
+    return  data.total + total;
+}
+
+export function sumDataTotalSimple(data){
+    let total = 0 ;
+    data.forEach(d => total += d.total);
+    return total ;
 }
 
 
@@ -62,6 +75,10 @@ function drawExpressionData(ctx, width, totalHeight, layout, data, labelHeight, 
             let d = rowData.slice(r.start, r.end + 1);
 
             let color = regionColor(d);
+
+            if(colorCount<100){
+                console.log('color',color);
+            }
 
             for (let y = rs + offsetHeight; y < rs + r.height + offsetHeight; ++y) {
                 let pxRow = y * width,

--- a/src/functions/SortFunctions.js
+++ b/src/functions/SortFunctions.js
@@ -78,8 +78,8 @@ export function clusterSort(prunedColumns) {
 
     renderedData = renderedData.sort(function (a, b) {
         for (let index = 0; index < a.length; ++index) {
-            if (a[index] !== b[index]) {
-                return b[index] - a[index];
+            if (a[index].total !== b[index].total) {
+                return b[index].total - a[index].total;
             }
         }
         return sumTotals(b) - sumTotals(a)
@@ -245,8 +245,8 @@ export function synchronizedSort(prunedColumns, geneList) {
 
     renderedData = renderedData.sort(function (a, b) {
         for (let index = 0; index < a.length; ++index) {
-            if (a[index] !== b[index]) {
-                return b[index] - a[index];
+            if (a[index].total !== b[index].total) {
+                return b[index].total - a[index].total;
             }
         }
         return sumTotals(b) - sumTotals(a)

--- a/src/functions/SortFunctions.js
+++ b/src/functions/SortFunctions.js
@@ -210,7 +210,6 @@ export function synchronizedGeneSetSort(prunedColumns, geneSetList) {
 
 export function synchronizedSort(prunedColumns, geneList) {
 
-    console.log('purned',prunedColumns)
     let sortedColumns = JSON.parse(JSON.stringify(prunedColumns));
     sortedColumns.pathways = scoreColumns(prunedColumns);
     let missingColumns = generateMissingColumns(sortedColumns.pathways, geneList);
@@ -228,8 +227,6 @@ export function synchronizedSort(prunedColumns, geneList) {
         return b.density - a.density
     });
     // refilter data by index
-    console.log(sortedColumns.data)
-    console.log('first',sortedColumns.data[0])
     let columnLength = sortedColumns.data[0].length;
     sortedColumns.data = sortedColumns.pathways.map(el => {
         let columnData = sortedColumns.data[el.index];

--- a/src/functions/SortFunctions.js
+++ b/src/functions/SortFunctions.js
@@ -210,6 +210,7 @@ export function synchronizedGeneSetSort(prunedColumns, geneSetList) {
 
 export function synchronizedSort(prunedColumns, geneList) {
 
+    console.log('purned',prunedColumns)
     let sortedColumns = JSON.parse(JSON.stringify(prunedColumns));
     sortedColumns.pathways = scoreColumns(prunedColumns);
     let missingColumns = generateMissingColumns(sortedColumns.pathways, geneList);
@@ -227,6 +228,8 @@ export function synchronizedSort(prunedColumns, geneList) {
         return b.density - a.density
     });
     // refilter data by index
+    console.log(sortedColumns.data)
+    console.log('first',sortedColumns.data[0])
     let columnLength = sortedColumns.data[0].length;
     sortedColumns.data = sortedColumns.pathways.map(el => {
         let columnData = sortedColumns.data[el.index];

--- a/src/functions/SortFunctions.js
+++ b/src/functions/SortFunctions.js
@@ -1,6 +1,6 @@
 import React from "react";
 import cluster from '../functions/Cluster';
-import {sum, sumInstances} from '../functions/util';
+import {sumTotals, sumInstances} from '../functions/util';
 
 export function transpose(a) {
     // return a[0].map(function (_, c) { return a.map(function (r) { return r[c]; }); });
@@ -82,7 +82,7 @@ export function clusterSort(prunedColumns) {
                 return b[index] - a[index];
             }
         }
-        return sum(b) - sum(a)
+        return sumTotals(b) - sumTotals(a)
     });
     renderedData = transpose(renderedData);
     let returnColumns = {};
@@ -105,7 +105,7 @@ export function clusterSampleSort(prunedColumns) {
     // - samples = N sample descriptions
     let transposedData = transpose(prunedColumns.data);
     let summedSamples = transposedData.map((d, index) => {
-        return {index: index, score: sum(d)}
+        return {index: index, score: sumTotals(d)}
     }).sort((a, b) => b.score - a.score);
     let sortedTransposedData = [];
     summedSamples.forEach((d,i) => {
@@ -194,7 +194,7 @@ export function synchronizedGeneSetSort(prunedColumns, geneSetList) {
                 return b[index] - a[index];
             }
         }
-        return sum(b) - sum(a)
+        return sumTotals(b) - sumTotals(a)
     });
 
     renderedData = transpose(renderedData);
@@ -249,7 +249,7 @@ export function synchronizedSort(prunedColumns, geneList) {
                 return b[index] - a[index];
             }
         }
-        return sum(b) - sum(a)
+        return sumTotals(b) - sumTotals(a)
     });
 
     renderedData = transpose(renderedData);

--- a/src/functions/util.js
+++ b/src/functions/util.js
@@ -51,7 +51,7 @@ export function partition(n, m) {
 export function sumInstances(arr) {
     let total = 0;
     for (let i = 0; i < arr.length; ++i) {
-        total += arr[i] > 0 ? 1 : 0 ;
+        total += arr[i].total > 0 ? 1 : 0 ;
     }
     return total;
 }
@@ -59,7 +59,7 @@ export function sumInstances(arr) {
 export function sum(arr) {
     let total = 0;
     for (let i = 0; i < arr.length; ++i) {
-        total += arr[i];
+        total += arr[i].total;
     }
     return total;
 }

--- a/src/functions/util.js
+++ b/src/functions/util.js
@@ -56,7 +56,7 @@ export function sumInstances(arr) {
     return total;
 }
 
-export function sum(arr) {
+export function sumTotals(arr) {
     let total = 0;
     for (let i = 0; i < arr.length; ++i) {
         total += arr[i].total;

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -3,7 +3,7 @@ import React from 'react'
 import {render, unmountComponentAtNode} from 'react-dom'
 
 import XenaGeneSetApp from "../src/components/XenaGeneSetApp";
-import {addIndepProb} from "../src/functions/DataFunctions";
+import {addIndepProb, createEmptyArray} from "../src/functions/DataFunctions";
 import {sumDataTotal} from "../src/functions/DrawFunctions";
 
 describe('Main App', () => {
@@ -62,12 +62,28 @@ describe('Test array fill', () => {
     });
 
     it('Calculates single function properly', () => {
-        let returnArray = new Array(20).fill(0).map(() => new Array(5).fill({total:0,mutation:0,cnv:0}));
+        let returnArray = new Array(20).fill([]).map(() => new Array(5).fill({total:0,mutation:0,cnv:0}));
         expect(returnArray.length,20);
         expect(returnArray[0].length,5);
         expect(returnArray[5][3],{total:0,mutation:0,cnv:0});
+        returnArray[5][3] = {total:7,mutation:3,cnv:1};
+        expect(returnArray[5][3],{total:7,mutation:3,cnv:1});
+        returnArray = new Array(20).fill(0).map(() => new Array(5).fill({total:0,mutation:0,cnv:0}));
+        expect(returnArray[5][3],{total:0,mutation:0,cnv:0});
+
     });
 
+    it('Create a simple array', () => {
+        let returnArray = createEmptyArray(20,5);
+        expect(returnArray.length,20);
+        expect(returnArray[0].length,5);
+        expect(returnArray[5][3],{total:0,mutation:0,cnv:0});
+        returnArray[5][3] = {total:7,mutation:3,cnv:1};
+        expect(returnArray[5][3],{total:7,mutation:3,cnv:1});
+        returnArray = new Array(20).fill(0).map(() => new Array(5).fill({total:0,mutation:0,cnv:0}));
+        expect(returnArray[5][3],{total:0,mutation:0,cnv:0});
+
+    });
     it('Test simple reduce of JSON',() => {
 
         let inputArray = [ {total:8,mutation:0,cnv:4},{total:2,mutation:0,cnv:2},{total:5,mutation:0,cnv:2},{total:7,mutation:0,cnv:3}];

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -3,8 +3,9 @@ import React from 'react'
 import {render, unmountComponentAtNode} from 'react-dom'
 
 import XenaGeneSetApp from "../src/components/XenaGeneSetApp";
-import {addIndepProb, createEmptyArray} from "../src/functions/DataFunctions";
+import {addIndepProb, createEmptyArray, DEFAULT_DATA_VALUE} from "../src/functions/DataFunctions";
 import {sumDataTotal} from "../src/functions/DrawFunctions";
+import {times} from "underscore";
 
 describe('Main App', () => {
   let node;
@@ -62,7 +63,9 @@ describe('Test array fill', () => {
     });
 
     it('Calculates single function properly', () => {
-        let returnArray = new Array(20).fill([]).map(() => new Array(5).fill({total:0,mutation:0,cnv:0}));
+        // let returnArray = new Array(20).fill([]).map(() => new Array(5).fill({total:0,mutation:0,cnv:0}));
+        // let returnArray = times(20,fill([]).map(() => new Array(5).fill({total:0,mutation:0,cnv:0}));
+        let returnArray = times(20, () => times(5, () => DEFAULT_DATA_VALUE));
         expect(returnArray.length,20);
         expect(returnArray[0].length,5);
         expect(returnArray[5][3],{total:0,mutation:0,cnv:0});

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -4,6 +4,7 @@ import {render, unmountComponentAtNode} from 'react-dom'
 
 import XenaGeneSetApp from "../src/components/XenaGeneSetApp";
 import {addIndepProb} from "../src/functions/DataFunctions";
+import {sumDataTotal} from "../src/functions/DrawFunctions";
 
 describe('Main App', () => {
   let node;
@@ -46,4 +47,32 @@ describe('Test statistical function', () => {
     it('Calculates multiple function properly 3', () => {
         expect([addIndepProb([0.8,0.05])]).toContain(0.81)
     });
+});
+
+
+describe('Test array fill', () => {
+    let node;
+
+    beforeEach(() => {
+        node = document.createElement('div')
+    });
+
+    afterEach(() => {
+        unmountComponentAtNode(node)
+    });
+
+    it('Calculates single function properly', () => {
+        let returnArray = new Array(20).fill(0).map(() => new Array(5).fill({total:0,mutation:0,cnv:0}));
+        expect(returnArray.length,20);
+        expect(returnArray[0].length,5);
+        expect(returnArray[5][3],{total:0,mutation:0,cnv:0});
+    });
+
+    it('Test simple reduce of JSON',() => {
+
+        let inputArray = [ {total:8,mutation:0,cnv:4},{total:2,mutation:0,cnv:2},{total:5,mutation:0,cnv:2},{total:7,mutation:0,cnv:3}];
+        let total = inputArray.reduce(sumDataTotal);
+        expect(total,8+2+7);
+    });
+
 });

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -4,7 +4,7 @@ import {render, unmountComponentAtNode} from 'react-dom'
 
 import XenaGeneSetApp from "../src/components/XenaGeneSetApp";
 import {addIndepProb, createEmptyArray, DEFAULT_DATA_VALUE} from "../src/functions/DataFunctions";
-import {sumDataTotal} from "../src/functions/DrawFunctions";
+import { sumDataTotalSimple} from "../src/functions/DrawFunctions";
 import {times} from "underscore";
 
 describe('Main App', () => {
@@ -87,11 +87,12 @@ describe('Test array fill', () => {
         expect(returnArray[5][3],{total:0,mutation:0,cnv:0});
 
     });
+
     it('Test simple reduce of JSON',() => {
-
         let inputArray = [ {total:8,mutation:0,cnv:4},{total:2,mutation:0,cnv:2},{total:5,mutation:0,cnv:2},{total:7,mutation:0,cnv:3}];
-        let total = inputArray.reduce(sumDataTotal);
-        expect(total,8+2+7);
+        let total = sumDataTotalSimple(inputArray);
+        // console.log(JSON.stringify(total))
+        // console.log(3)
+        expect(total===8+2+5+7);
     });
-
 });

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -90,7 +90,7 @@ describe('Test array fill', () => {
 
     it('Test simple reduce of JSON',() => {
         let inputArray = [ {total:8,mutation:0,cnv:4},{total:2,mutation:0,cnv:2},{total:5,mutation:0,cnv:2},{total:7,mutation:0,cnv:3}];
-        let total = sumDataTotalSimple(inputArray);
+        let total = sumDataTotalSimple(inputArray,'total');
         // console.log(JSON.stringify(total))
         // console.log(3)
         expect(total===8+2+5+7);


### PR DESCRIPTION
fixes #223 

- [x] fix but that requires a refresh after changing data
- [x] make it configurable somehow (total, cnv / mutation split - or one of each)
- ~~address performance (use arrays?, imbed as a byte)~~ not seeing this when comparing production environemtns

---

- [x] split coloring horizontally based on hit type from JSON
- [x] make "hits" show specific hit types: cnv, mutation, total

----

- [x] convert drawing function to mimic current using "total"
  - [x] fix hover option
  - [x] fix count for CNV / Mutation
  - [x] samples affected / objects alternate (is 0)
  - [x] fix sample sort option

---
- [x] convert downstream sorting functions (and other instances to the same)
- [x] convert associateData to  JSON object with total, and hit type for each
- [x] remove extraneous `data` call in CanvasDrawing
