### PR TITLE
Fix 613 v2

### DIFF
--- a/src/components/GeneSetEditor.js
+++ b/src/components/GeneSetEditor.js
@@ -64,7 +64,7 @@ export default class GeneSetEditor extends PureComponent {
       limit: VIEW_LIMIT,
       newGeneStateName:'',
       showLoading:true,
-      customGeneSetName: this.props.customGeneSetName,
+      customGeneSetName: this.props.customGeneSetName || '',
     }
   }
 
@@ -338,12 +338,13 @@ export default class GeneSetEditor extends PureComponent {
     })
   }
 
-  handleViewGeneSets(doView) {
+  handleViewGeneSets(genesetToShow) {
+    console.log('viewing ',genesetToShow)
     if(this.state.customGeneSetName){
       const selectedCartData = this.getSelectedCartData()
       this.props.storeCustomGeneSets(this.state.customGeneSetName,selectedCartData)
-      if(doView){
-        this.props.setPathways(selectedCartData)
+      if(genesetToShow){
+        this.props.setPathways(selectedCartData,genesetToShow)
       }
       // this.props.setPathways(this.props.(this.state.customGeneSetName))
     }
@@ -444,9 +445,9 @@ export default class GeneSetEditor extends PureComponent {
               <td colSpan={3}>
                 Custom Gene Set Name:
                 <input
-                  onChange={(input) => {
+                  onChange={(input) =>
                     this.setState({customGeneSetName:input.target.value})
-                  }}
+                  }
                   placeholder={'Custom Gene Set Name'}
                   size={50}
                   style={{marginBottom: 10}}
@@ -666,7 +667,7 @@ export default class GeneSetEditor extends PureComponent {
                   <Button
                     disabled={this.state.editGeneSet !== undefined}
                     label='Save and View' mini
-                    onClick={() => this.handleViewGeneSets(true)}
+                    onClick={() => this.handleViewGeneSets(this.state.customGeneSetName)}
                     primary raised
                   />
                   <Button

--- a/src/components/GeneSetEditor.js
+++ b/src/components/GeneSetEditor.js
@@ -457,7 +457,11 @@ export default class GeneSetEditor extends PureComponent {
                   disabled={false}
                   floating
                   mini
-                  onClick={() => alert(`remove gene set ${this.state.customGeneSetName}`)}
+                  onClick={() => {
+                    if(confirm(`Remove gene sets ${this.state.customGeneSetName}`)){
+                      this.props.removeCustomGeneSet(this.state.customGeneSetName)
+                    }
+                  }}
                   raised
                   style={{marginLeft: 20}}
                 >

--- a/src/components/GeneSetEditor.js
+++ b/src/components/GeneSetEditor.js
@@ -130,9 +130,21 @@ export default class GeneSetEditor extends PureComponent {
 
     const pathwayLabels = this.props.pathways.map( p => p.golabel)
     // included data from original pathways
-    let cartPathways = loadedPathways.filter( p =>  pathwayLabels.indexOf(p.golabel)>=0 )
-    const cartLabels = cartPathways.map( p => p.golabel)
-    cartPathways = [...cartPathways,...this.props.pathways.filter( p => cartLabels.indexOf(p.golabel)<0 )]
+    let cartPathways
+    console.log('loading cart')
+    if(this.props.customGeneSetName && this.props.isCustomGeneSet(this.state.customGeneSetName)){
+      // TODO, may need to interset
+      cartPathways = this.props.getCustomGeneSet(this.state.customGeneSetName)
+      console.log('loaded cart pathways from',this.state.customGeneSetName,cartPathways)
+      // cartPathways = loadedPathways.filter( p =>  pathwayLabels.indexOf(p.golabel)>=0 )
+    }
+    else{
+      cartPathways = loadedPathways.filter( p =>  pathwayLabels.indexOf(p.golabel)>=0 )
+      const cartLabels = cartPathways.map( p => p.golabel)
+      cartPathways = [...cartPathways,...this.props.pathways.filter( p => cartLabels.indexOf(p.golabel)<0 )]
+      console.log('loaded cart pathways',cartPathways)
+    }
+
 
 
     this.setState({
@@ -671,8 +683,12 @@ export default class GeneSetEditor extends PureComponent {
 GeneSetEditor.propTypes = {
   cancelPathwayEdit: PropTypes.any.isRequired,
   customGeneSetName: PropTypes.any,
+  getAvailableCustomGeneSets: PropTypes.any.isRequired,
+  getCustomGeneSet: PropTypes.any.isRequired,
+  isCustomGeneSet: PropTypes.any.isRequired,
   pathwayData: PropTypes.array.isRequired,
   pathways: PropTypes.any.isRequired,
+  removeCustomGeneSet: PropTypes.any.isRequired,
   setPathways: PropTypes.any.isRequired,
   storeCustomGeneSets: PropTypes.any.isRequired,
   view: PropTypes.any.isRequired,

--- a/src/components/GeneSetEditor.js
+++ b/src/components/GeneSetEditor.js
@@ -48,7 +48,6 @@ export default class GeneSetEditor extends PureComponent {
       sortCartOrder:sortingOptions.sortViewOrder,
       sortCartOrderLabel:SORT_VIEW_BY.DIFFERENT,
       sortCartBy: sortingOptions.sortViewBy,
-      geneSet: '8K',
       newGene: [],
       geneOptions: [],
       loadedPathways,
@@ -93,9 +92,6 @@ export default class GeneSetEditor extends PureComponent {
       this.sortVisibleCartByLabel(this.state.sortCartOrderLabel)
       // this.sortVisibleCart(this.state.sortCartBy,this.state.sortCartOrder,this.state.cartPathwayLimit)
     }
-
-    // if(prevState.sortCartOrder !== this.state.sortCartOrder){
-    // }
   }
 
   showScore(){
@@ -210,10 +206,9 @@ export default class GeneSetEditor extends PureComponent {
       console.warn(alreadyExists.map( f => f.golabel).join(' ')+ ' already in cart' )
     }
 
-    const selectedCartData = update(this.state.cartPathways, {
+    return update(this.state.cartPathways, {
       $push: selectedFilteredPathways
     })
-    return selectedCartData
   }
 
   handleAddSelectedToCart() {
@@ -238,13 +233,13 @@ export default class GeneSetEditor extends PureComponent {
     })
   }
 
-  handleRefreshView() {
-    const newCart = this.state.filteredPathways.slice(0,this.state.cartPathwayLimit)
-    this.setState({
-      cartPathways: newCart,
-      filteredCartPathways: this.getFilteredCart(newCart,this.state.sortCartBy,this.state.sortCartOrder)
-    })
-  }
+  // handleRefreshView() {
+  //   const newCart = this.state.filteredPathways.slice(0,this.state.cartPathwayLimit)
+  //   this.setState({
+  //     cartPathways: newCart,
+  //     filteredCartPathways: this.getFilteredCart(newCart,this.state.sortCartBy,this.state.sortCartOrder)
+  //   })
+  // }
 
   handleNewGeneSet() {
     const newGeneSet = {

--- a/src/components/GeneSetEditor.js
+++ b/src/components/GeneSetEditor.js
@@ -668,13 +668,13 @@ export default class GeneSetEditor extends PureComponent {
               <td colSpan={3}>
                 <div style={{marginTop: 10}}>
                   <Button
-                    disabled={this.state.editGeneSet !== undefined}
+                    disabled={this.state.editGeneSet !== undefined || !this.state.customGeneSetName}
                     label='Save and View' mini
                     onClick={() => this.handleViewGeneSets(this.state.customGeneSetName)}
                     primary raised
                   />
                   <Button
-                    disabled={this.state.editGeneSet !== undefined}
+                    disabled={this.state.editGeneSet !== undefined || !this.state.customGeneSetName}
                     label='Save Only and Close' mini
                     onClick={() => this.handleViewGeneSets()}
                     raised

--- a/src/components/GeneSetEditor.js
+++ b/src/components/GeneSetEditor.js
@@ -131,18 +131,15 @@ export default class GeneSetEditor extends PureComponent {
     const pathwayLabels = this.props.pathways.map( p => p.golabel)
     // included data from original pathways
     let cartPathways
-    console.log('loading cart')
     if(this.props.customGeneSetName && this.props.isCustomGeneSet(this.state.customGeneSetName)){
       // TODO, may need to interset
       cartPathways = this.props.getCustomGeneSet(this.state.customGeneSetName)
-      console.log('loaded cart pathways from',this.state.customGeneSetName,cartPathways)
       // cartPathways = loadedPathways.filter( p =>  pathwayLabels.indexOf(p.golabel)>=0 )
     }
     else{
       cartPathways = loadedPathways.filter( p =>  pathwayLabels.indexOf(p.golabel)>=0 )
       const cartLabels = cartPathways.map( p => p.golabel)
       cartPathways = [...cartPathways,...this.props.pathways.filter( p => cartLabels.indexOf(p.golabel)<0 )]
-      console.log('loaded cart pathways',cartPathways)
     }
 
 
@@ -339,7 +336,6 @@ export default class GeneSetEditor extends PureComponent {
   }
 
   handleViewGeneSets(genesetToShow) {
-    console.log('viewing ',genesetToShow)
     if(this.state.customGeneSetName){
       const selectedCartData = this.getSelectedCartData()
       this.props.storeCustomGeneSets(this.state.customGeneSetName,selectedCartData)

--- a/src/components/GeneSetEditor.js
+++ b/src/components/GeneSetEditor.js
@@ -338,11 +338,13 @@ export default class GeneSetEditor extends PureComponent {
     })
   }
 
-  // TODO: push back to production pathways
-  handleViewGeneSets() {
+  handleViewGeneSets(doView) {
     if(this.state.customGeneSetName){
       const selectedCartData = this.getSelectedCartData()
       this.props.storeCustomGeneSets(this.state.customGeneSetName,selectedCartData)
+      if(doView){
+        this.props.setPathways(selectedCartData)
+      }
       // this.props.setPathways(this.props.(this.state.customGeneSetName))
     }
     else{
@@ -659,9 +661,15 @@ export default class GeneSetEditor extends PureComponent {
                 <div style={{marginTop: 10}}>
                   <Button
                     disabled={this.state.editGeneSet !== undefined}
-                    label='Save View' mini
-                    onClick={() => this.handleViewGeneSets()}
+                    label='Save and View' mini
+                    onClick={() => this.handleViewGeneSets(true)}
                     primary raised
+                  />
+                  <Button
+                    disabled={this.state.editGeneSet !== undefined}
+                    label='Save' mini
+                    onClick={() => this.handleViewGeneSets()}
+                    raised
                   />
                   <Button
                     label='Cancel' mini

--- a/src/components/GeneSetEditor.js
+++ b/src/components/GeneSetEditor.js
@@ -479,31 +479,6 @@ export default class GeneSetEditor extends PureComponent {
                     </tr>
                     <tr>
                       <td>
-                        {/*{this.state.sortOrder === SORT_ORDER_ENUM.ASC &&*/}
-                        {/*<button*/}
-                        {/*  className={BaseStyle.refreshButton}*/}
-                        {/*  onClick={() => {*/}
-                        {/*    this.setState({*/}
-                        {/*      sortOrder: SORT_ORDER_ENUM.DESC,*/}
-                        {/*    })*/}
-                        {/*  }}*/}
-                        {/*>*/}
-                        {/*  Score*/}
-                        {/*  <FaSortAsc/>*/}
-                        {/*</button>*/}
-                        {/*}*/}
-                        {/*{this.state.sortOrder === SORT_ORDER_ENUM.DESC &&*/}
-                        {/*<button*/}
-                        {/*  className={BaseStyle.refreshButton}*/}
-                        {/*  onClick={() => {*/}
-                        {/*    this.setState({*/}
-                        {/*      sortOrder: SORT_ORDER_ENUM.ASC,*/}
-                        {/*    })}}*/}
-                        {/*>*/}
-                        {/*  Score*/}
-                        {/*  <FaSortDesc />*/}
-                        {/*</button>*/}
-                        {/*}*/}
                         &nbsp;Results: {this.state.totalPathways}
                       </td>
                     </tr>
@@ -676,11 +651,6 @@ export default class GeneSetEditor extends PureComponent {
                     onClick={() => this.handleViewGeneSets()}
                     primary raised
                   />
-                  {/*<Button*/}
-                  {/*  label='Reset' mini*/}
-                  {/*  onClick={() => this.handleResetGeneSets()}*/}
-                  {/*  raised*/}
-                  {/*/>*/}
                   <Button
                     label='Cancel' mini
                     onClick={() => this.handleCancel()}

--- a/src/components/GeneSetEditor.js
+++ b/src/components/GeneSetEditor.js
@@ -346,6 +346,9 @@ export default class GeneSetEditor extends PureComponent {
       if(genesetToShow){
         this.props.setPathways(selectedCartData,genesetToShow)
       }
+      else{
+        this.props.cancelPathwayEdit()
+      }
       // this.props.setPathways(this.props.(this.state.customGeneSetName))
     }
     else{
@@ -661,8 +664,8 @@ export default class GeneSetEditor extends PureComponent {
             }
             {!this.state.editGeneSet &&
             <tr>
-              <td colSpan={2}/>
-              <td colSpan={1}>
+              {/*<td colSpan={1}/>*/}
+              <td colSpan={3}>
                 <div style={{marginTop: 10}}>
                   <Button
                     disabled={this.state.editGeneSet !== undefined}
@@ -672,7 +675,7 @@ export default class GeneSetEditor extends PureComponent {
                   />
                   <Button
                     disabled={this.state.editGeneSet !== undefined}
-                    label='Save' mini
+                    label='Save Only and Close' mini
                     onClick={() => this.handleViewGeneSets()}
                     raised
                   />

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -588,7 +588,6 @@ export default class XenaGeneSetApp extends PureComponent {
   }
 
   setActiveGeneSets = (newPathways,selectedGeneSets) => {
-    console.log('setting new paths',newPathways,selectedGeneSets)
     AppStorageHandler.storePathways(newPathways)
 
     const defaultPathway = update( newPathways[0],{
@@ -603,7 +602,6 @@ export default class XenaGeneSetApp extends PureComponent {
         pathwaySelection[0] :
         defaultPathway,
     }
-
 
     this.setState({
       pathwaySelection,
@@ -678,9 +676,6 @@ export default class XenaGeneSetApp extends PureComponent {
   handleGeneSetLimit = (limit,method,geneSet) => {
     currentLoadState= LOAD_STATE.LOADED
     let {sortViewBy,sortViewOrder,filterBy,filterOrder} = calculateSortingByMethod(method)
-    console.log('limit',limit)
-    console.log('method',method)
-    console.log('geneSet',geneSet)
     this.setState({
       selectedGenSet: geneSet,
       reloadPathways: true,
@@ -703,7 +698,6 @@ export default class XenaGeneSetApp extends PureComponent {
   }
 
   removeCustomGeneSet = (name) => {
-    console.log('removing gene set input name',name,this.state.customGeneSets)
     const newCustomGeneSets = update(this.state.customGeneSets,{
       $unset: [name]
     })
@@ -718,7 +712,6 @@ export default class XenaGeneSetApp extends PureComponent {
 
   storeCustomGeneSet = (name,geneSet) => {
     // this.state.customGeneSets[name] = geneSet
-    console.log('storing gene set input name',name,geneSet,this.state.customGeneSets)
     const newCustomGeneSets = update(this.state.customGeneSets,{
       [name]: { $set:geneSet}
     })

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -673,16 +673,27 @@ export default class XenaGeneSetApp extends PureComponent {
     })
   }
 
-  getAvailableCustomGeneSets(){
+  getAvailableCustomGeneSets = () => {
     return Object.keys(this.state.customGeneSets)
   }
 
-  getCustomGeneSet(name){
+  getCustomGeneSet = (name) => {
     return this.state.customGeneSets[name]
   }
 
-  storeCustomGeneSet(name,geneSet){
+  removeCustomGeneSet = (name) => {
+    console.log('removing gene set input name',name,this.state.customGeneSets)
+    const newCustomGeneSets = this.state.customGeneSets.filter( f => f.key !== name )
+    this.setState({
+      customGeneSets: newCustomGeneSets
+    })
+
+    this.setActiveGeneSets(newCustomGeneSets)
+  }
+
+  storeCustomGeneSet = (name,geneSet) => {
     // this.state.customGeneSets[name] = geneSet
+    console.log('storing gene set input name',name,geneSet,this.state.customGeneSets)
     const newCustomGeneSets = update(this.state.customGeneSets,{
       [name]: { $set:geneSet}
     })

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -707,10 +707,6 @@ export default class XenaGeneSetApp extends PureComponent {
 
     // this.setActiveGeneSets(newCustomGeneSets)
   }
-  storeAndViewCustomGeneSet = (name,geneSet) => {
-    this.storeCustomGeneSet(name,geneSet)
-    this.setActiveGeneSets(geneSet)
-  }
 
   storeCustomGeneSet = (name,geneSet) => {
     // this.state.customGeneSets[name] = geneSet

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -581,8 +581,14 @@ export default class XenaGeneSetApp extends PureComponent {
     })
   };
 
+  setGeneSetOption = (selectedGeneSets) => {
+    this.setState({
+      selectedGeneSets,
+    })
+  }
 
-  setActiveGeneSets = (newPathways) => {
+  setActiveGeneSets = (newPathways,selectedGeneSets) => {
+    console.log('setting new paths',newPathways,selectedGeneSets)
     AppStorageHandler.storePathways(newPathways)
 
     const defaultPathway = update( newPathways[0],{
@@ -597,9 +603,12 @@ export default class XenaGeneSetApp extends PureComponent {
         pathwaySelection[0] :
         defaultPathway,
     }
+
+
     this.setState({
       pathwaySelection,
       showGeneSetSearch: false,
+      selectedGeneSets,
       pathways: newPathways,
       fetch: true,
       reloadPathways: false,
@@ -783,7 +792,9 @@ export default class XenaGeneSetApp extends PureComponent {
           maxValue={maxValue}
           onChangeGeneSetLimit={this.handleGeneSetLimit}
           onShowDiffLabel={() => this.setState( { showDiffLabel: !this.state.showDiffLabel})}
+          selectedGeneSets={this.state.selectedGeneSets}
           setActiveGeneSets={this.setActiveGeneSets}
+          setGeneSetsOption={this.setGeneSetOption}
           showDiffLabel={this.state.showDiffLabel}
           sortGeneSetBy={this.state.sortViewByLabel}
           view={this.state.filter}

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -757,7 +757,7 @@ export default class XenaGeneSetApp extends PureComponent {
         // if its not gene expression just use the canned data
         if (!isViewGeneExpression(this.state.filter)) {
           // this.getCustomGeneSet(this.state.selectedGeneSets)
-          pathways = getGeneSetsForView(this.state.filter,this.getCustomPathways(this.state.selectedGeneSets))
+          pathways = getGeneSetsForView(this.state.filter)
         }
 
         fetchCombinedCohorts(this.state.selectedCohort, pathways,

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -700,43 +700,43 @@ export default class XenaGeneSetApp extends PureComponent {
   }
 
   getAvailableCustomGeneSets = () => {
-    return Object.keys(this.state.customGeneSets)
+    return Object.keys(this.state.customGeneSets[this.state.filter])
   }
 
   getCustomGeneSet = (name) => {
-    return this.state.customGeneSets[name]
+    return this.state.customGeneSets[this.state.filter][name]
   }
 
   removeCustomGeneSet = (name) => {
-    const newCustomGeneSets = update(this.state.customGeneSets,{
-      $unset: [name]
-    })
+    let customGeneSets = JSON.parse(JSON.stringify(this.state.customGeneSets))
+    delete customGeneSets[this.state.filter][name]
+    // const newCustomGeneSets = update(this.state.customGeneSets[this.state.filter],{
+    //   $unset: [name]
+    // })
+    const newCustomGeneSets = JSON.parse(JSON.stringify(customGeneSets))
     this.setState({
       customGeneSets: newCustomGeneSets,
       showGeneSetSearch: false,
     })
 
     AppStorageHandler.storeCustomPathways(newCustomGeneSets)
-    // this.setActiveGeneSets(newCustomGeneSets)
   }
 
   storeCustomGeneSet = (name,geneSet) => {
-    // this.state.customGeneSets[name] = geneSet
-    const newCustomGeneSets = update(this.state.customGeneSets,{
-      [name]: { $set:geneSet}
-    })
+    let customGeneSets = JSON.parse(JSON.stringify(this.state.customGeneSets))
+    customGeneSets[this.state.filter][name] = geneSet
+    // const newCustomGeneSets = update(this.state.customGeneSets,{
+    //   [this.state.view]:{[name]: { $set:geneSet}}
+    // })
+    const newCustomGeneSets = JSON.parse(JSON.stringify(customGeneSets))
     this.setState({
       customGeneSets: newCustomGeneSets
     })
     AppStorageHandler.storeCustomPathways(newCustomGeneSets)
   }
 
-  renameCustomGeneSet = (name) => {
-    return (this.state.customGeneSets[name]!==undefined)
-  }
-
   isCustomGeneSet = (name) => {
-    return (this.state.customGeneSets[name]!==undefined)
+    return (this.state.customGeneSets[this.state.filter][name]!==undefined)
   }
 
 

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -114,7 +114,7 @@ export default class XenaGeneSetApp extends PureComponent {
       showColorEditor: false,
       showCohortEditor: false,
       showDiffLabel: true,
-      selectedGeneSet: undefined,
+      selectedGeneSets: urlVariables.selectedGeneSets,
       customGeneSets: AppStorageHandler.getCustomPathways(),
       geneSetLimit: urlVariables.geneSetLimit ?urlVariables.geneSetLimit : DEFAULT_GENE_SET_LIMIT,
       filter,
@@ -156,6 +156,7 @@ export default class XenaGeneSetApp extends PureComponent {
       this.state.selectedCohort[1].selectedSubCohorts,
       this.state.geneSetLimit,
       this.state.sortViewByLabel,
+      this.state.selectedGeneSets,
     )
     if (location.hash !== generatedUrl) {
       location.hash = generatedUrl

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -704,7 +704,7 @@ export default class XenaGeneSetApp extends PureComponent {
     this.setActiveGeneSets(geneSet)
   }
 
-  isCustomGeneSet(name){
+  isCustomGeneSet = (name) => {
     return (this.state.customGeneSets[name]!==undefined)
   }
 
@@ -764,10 +764,12 @@ export default class XenaGeneSetApp extends PureComponent {
           geneData={this.state.geneData}
           geneSetLimit={this.state.geneSetLimit}
           handleGeneEdit={this.showConfiguration}
+          isCustomGeneSet={this.isCustomGeneSet}
           maxGeneData={this.state.maxGeneData}
           maxValue={maxValue}
           onChangeGeneSetLimit={this.handleGeneSetLimit}
           onShowDiffLabel={() => this.setState( { showDiffLabel: !this.state.showDiffLabel})}
+          setActiveGeneSets={this.setActiveGeneSets}
           showDiffLabel={this.state.showDiffLabel}
           sortGeneSetBy={this.state.sortViewByLabel}
           view={this.state.filter}

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -602,6 +602,15 @@ export default class XenaGeneSetApp extends PureComponent {
         pathwaySelection[0] :
         defaultPathway,
     }
+    //
+    // console.log('filter order',this.state.filterBy,this.state.filterOrder,scorePathway(newPathways[0],this.state.filterBy))
+    // const sortedPathways = newPathways.sort((a, b) => (this.state.sortViewOrder === SORT_ORDER_ENUM.ASC ?
+    //   1 :
+    //   -1) * (scorePathway(a, this.state.sortViewBy) -
+    //   scorePathway(b, this.state.sortViewBy)))
+    //
+    // console.log('new pathways',newPathways)
+    // console.log('sorted pathways',sortedPathways,sortedPathways.map( s =>  s.firstGeneExpressionPathwayActivity - s.secondGeneExpressionPathwayActivity))
 
     this.setState({
       pathwaySelection,

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -578,6 +578,7 @@ export default class XenaGeneSetApp extends PureComponent {
       fetch: true,
       reloadPathways: this.state.automaticallyReloadPathways,
       showCohortEditor: false,
+      selectedGeneSets: newView!== this.state.filter?  undefined : this.state.selectedGeneSets
     })
   };
 

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -115,6 +115,7 @@ export default class XenaGeneSetApp extends PureComponent {
       showColorEditor: false,
       showCohortEditor: false,
       showDiffLabel: true,
+      selectedGeneSet: undefined,
       customGeneSets: {},
       geneSetLimit: urlVariables.geneSetLimit ?urlVariables.geneSetLimit : DEFAULT_GENE_SET_LIMIT,
       filter,
@@ -658,10 +659,14 @@ export default class XenaGeneSetApp extends PureComponent {
       this.state.filter, this.handleCombinedCohortData)
   };
 
-  handleGeneSetLimit = (limit,method) => {
+  handleGeneSetLimit = (limit,method,geneSet) => {
     currentLoadState= LOAD_STATE.LOADED
     let {sortViewBy,sortViewOrder,filterBy,filterOrder} = calculateSortingByMethod(method)
+    console.log('limit',limit)
+    console.log('method',method)
+    console.log('geneSet',geneSet)
     this.setState({
+      selectedGenSet: geneSet,
       reloadPathways: true,
       geneSetLimit: limit,
       sortViewByLabel: method,
@@ -831,7 +836,7 @@ export default class XenaGeneSetApp extends PureComponent {
             const topClient = ev.currentTarget.getBoundingClientRect().top
             // some fudge factors in here
             const x = ev.clientX + 9
-            const y = ev.clientY + 305 - topClient
+            const y = ev.clientY + 325 - topClient
             // if (    ((x >= 265 && x <= 445) || (x >= 673 && x <= 853)) ) {
             if ( x >= 265 && x <= 853 ) {
               this.setState({mousing: true, x, y})

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -887,8 +887,12 @@ export default class XenaGeneSetApp extends PureComponent {
               cancelPathwayEdit={() => this.setState(
                 {showGeneSetSearch: false})}
               customGeneSetName={this.state.selectedGeneSet}
+              getAvailableCustomGeneSets={this.getAvailableCustomGeneSets}
+              getCustomGeneSet={this.getCustomGeneSet}
+              isCustomGeneSet={this.isCustomGeneSet}
               pathwayData={this.state.pathwayData}
               pathways={this.state.pathways}
+              removeCustomGeneSet={this.removeCustomGeneSet}
               setPathways={this.setActiveGeneSets}
               storeCustomGeneSets={this.storeCustomGeneSet}
               view={this.state.filter}

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -659,7 +659,14 @@ export default class XenaGeneSetApp extends PureComponent {
         1 :
         -1) * (scorePathway(a, this.state.filterBy) -
         scorePathway(b, this.state.filterBy))).
-      slice(0, this.state.geneSetLimit).
+      filter( (c) => {
+        if(this.state.selectedGeneSets && this.state.selectedGeneSets.indexOf('Default')<0){
+          const currentGeneSets = this.getCustomGeneSet(this.state.selectedGeneSets).map( f => f.golabel )
+          return currentGeneSets.indexOf(c.golabel)>=0
+        }
+        return true
+      })
+      .slice(0, this.state.geneSetLimit).
       sort((a, b) => (this.state.sortViewOrder === SORT_ORDER_ENUM.ASC ?
         1 :
         -1) * (scorePathway(a, this.state.sortViewBy) -
@@ -749,7 +756,8 @@ export default class XenaGeneSetApp extends PureComponent {
       } else {
         // if its not gene expression just use the canned data
         if (!isViewGeneExpression(this.state.filter)) {
-          pathways = getGeneSetsForView(this.state.filter)
+          // this.getCustomGeneSet(this.state.selectedGeneSets)
+          pathways = getGeneSetsForView(this.state.filter,this.getCustomPathways(this.state.selectedGeneSets))
         }
 
         fetchCombinedCohorts(this.state.selectedCohort, pathways,

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -683,12 +683,15 @@ export default class XenaGeneSetApp extends PureComponent {
 
   removeCustomGeneSet = (name) => {
     console.log('removing gene set input name',name,this.state.customGeneSets)
-    const newCustomGeneSets = this.state.customGeneSets.filter( f => f.key !== name )
+    const newCustomGeneSets = update(this.state.customGeneSets,{
+      $unset: [name]
+    })
     this.setState({
-      customGeneSets: newCustomGeneSets
+      customGeneSets: newCustomGeneSets,
+      showGeneSetSearch: false,
     })
 
-    this.setActiveGeneSets(newCustomGeneSets)
+    // this.setActiveGeneSets(newCustomGeneSets)
   }
   storeAndViewCustomGeneSet = (name,geneSet) => {
     this.storeCustomGeneSet(name,geneSet)

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -101,7 +101,6 @@ export default class XenaGeneSetApp extends PureComponent {
 
 
 
-
     this.state = {
       associatedData: [],
       selectedCohort: cohorts,
@@ -116,7 +115,7 @@ export default class XenaGeneSetApp extends PureComponent {
       showCohortEditor: false,
       showDiffLabel: true,
       selectedGeneSet: undefined,
-      customGeneSets: {},
+      customGeneSets: AppStorageHandler.getCustomPathways(),
       geneSetLimit: urlVariables.geneSetLimit ?urlVariables.geneSetLimit : DEFAULT_GENE_SET_LIMIT,
       filter,
 
@@ -705,6 +704,7 @@ export default class XenaGeneSetApp extends PureComponent {
       showGeneSetSearch: false,
     })
 
+    AppStorageHandler.storeCustomPathways(newCustomGeneSets)
     // this.setActiveGeneSets(newCustomGeneSets)
   }
 
@@ -717,6 +717,7 @@ export default class XenaGeneSetApp extends PureComponent {
     this.setState({
       customGeneSets: newCustomGeneSets
     })
+    AppStorageHandler.storeCustomPathways(newCustomGeneSets)
   }
 
   renameCustomGeneSet = (name) => {

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -690,6 +690,10 @@ export default class XenaGeneSetApp extends PureComponent {
 
     this.setActiveGeneSets(newCustomGeneSets)
   }
+  storeAndViewCustomGeneSet = (name,geneSet) => {
+    this.storeCustomGeneSet(name,geneSet)
+    this.setActiveGeneSets(geneSet)
+  }
 
   storeCustomGeneSet = (name,geneSet) => {
     // this.state.customGeneSets[name] = geneSet
@@ -700,8 +704,10 @@ export default class XenaGeneSetApp extends PureComponent {
     this.setState({
       customGeneSets: newCustomGeneSets
     })
+  }
 
-    this.setActiveGeneSets(geneSet)
+  renameCustomGeneSet = (name) => {
+    return (this.state.customGeneSets[name]!==undefined)
   }
 
   isCustomGeneSet = (name) => {

--- a/src/components/legend/LegendBox.js
+++ b/src/components/legend/LegendBox.js
@@ -43,7 +43,9 @@ export class LegendBox extends PureComponent {
                 isCustomGeneSet={this.props.isCustomGeneSet}
                 onChangeGeneSetLimit={this.props.onChangeGeneSetLimit}
                 onGeneEdit={this.props.handleGeneEdit}
+                selectedGeneSets={this.props.selectedGeneSets}
                 setActiveGeneSets={this.props.setActiveGeneSets}
+                setGeneSetsOption={this.props.setGeneSetsOption}
                 sortGeneSetBy={this.props.sortGeneSetBy}
               />
               }
@@ -99,7 +101,9 @@ LegendBox.propTypes = {
   maxValue: PropTypes.any.isRequired,
   onChangeGeneSetLimit: PropTypes.any.isRequired,
   onShowDiffLabel: PropTypes.any.isRequired,
+  selectedGeneSets: PropTypes.any,
   setActiveGeneSets: PropTypes.any.isRequired,
+  setGeneSetsOption: PropTypes.any.isRequired,
   showDiffLabel: PropTypes.any.isRequired,
   sortGeneSetBy: PropTypes.any.isRequired,
   view: PropTypes.any.isRequired,

--- a/src/components/legend/LegendBox.js
+++ b/src/components/legend/LegendBox.js
@@ -40,8 +40,10 @@ export class LegendBox extends PureComponent {
               <OpenGeneSetRow
                 customGeneSets={this.props.customGeneSets}
                 geneSetLimit={this.props.geneSetLimit}
+                isCustomGeneSet={this.props.isCustomGeneSet}
                 onChangeGeneSetLimit={this.props.onChangeGeneSetLimit}
                 onGeneEdit={this.props.handleGeneEdit}
+                setActiveGeneSets={this.props.setActiveGeneSets}
                 sortGeneSetBy={this.props.sortGeneSetBy}
               />
               }
@@ -92,10 +94,12 @@ LegendBox.propTypes = {
   geneData: PropTypes.any.isRequired,
   geneSetLimit: PropTypes.any.isRequired,
   handleGeneEdit: PropTypes.any.isRequired,
+  isCustomGeneSet: PropTypes.any.isRequired,
   maxGeneData: PropTypes.any.isRequired,
   maxValue: PropTypes.any.isRequired,
   onChangeGeneSetLimit: PropTypes.any.isRequired,
   onShowDiffLabel: PropTypes.any.isRequired,
+  setActiveGeneSets: PropTypes.any.isRequired,
   showDiffLabel: PropTypes.any.isRequired,
   sortGeneSetBy: PropTypes.any.isRequired,
   view: PropTypes.any.isRequired,

--- a/src/components/legend/LegendBox.js
+++ b/src/components/legend/LegendBox.js
@@ -38,7 +38,7 @@ export class LegendBox extends PureComponent {
               {/*Gene Set Editor / Selector controls*/}
               { isViewGeneExpression(this.props.view) &&
               <OpenGeneSetRow
-                customGeneSets={this.props.customGeneSets}
+                customGeneSets={this.props.customGeneSets[this.props.view]}
                 geneSetLimit={this.props.geneSetLimit}
                 isCustomGeneSet={this.props.isCustomGeneSet}
                 onChangeGeneSetLimit={this.props.onChangeGeneSetLimit}

--- a/src/components/legend/OpenGeneSetRow.js
+++ b/src/components/legend/OpenGeneSetRow.js
@@ -37,8 +37,6 @@ export class OpenGeneSetRow extends PureComponent {
 
   render() {
 
-    console.log('input props',this.props,this.props.customGeneSets,this.state.selectedGeneSets,this.props.selectedGeneSets)
-
     return (
       <tr className={BaseStyle.openGeneSetRow} >
         <td colSpan={3} width={DETAIL_WIDTH+LABEL_WIDTH+DETAIL_WIDTH}>

--- a/src/components/legend/OpenGeneSetRow.js
+++ b/src/components/legend/OpenGeneSetRow.js
@@ -45,9 +45,7 @@ export class OpenGeneSetRow extends PureComponent {
                       className={BaseStyle.refreshButton}
                       onClick={() => this.props.onChangeGeneSetLimit(this.state.geneSetLimit,this.state.sortGeneSetBy)}>
                       Find <FaSearch/>
-                      {/*<FaSearch/>*/}
                     </button>
-                    {/*<div className={BaseStyle.editGeneSetSearch}>Find</div>*/}
                     <div className={BaseStyle.editGeneSetSearch}>the</div>
                     <input
                       className={BaseStyle.editGeneSetLimits} onChange={(limit) => this.setState({geneSetLimit: limit.target.value})}

--- a/src/components/legend/OpenGeneSetRow.js
+++ b/src/components/legend/OpenGeneSetRow.js
@@ -28,6 +28,9 @@ export class OpenGeneSetRow extends PureComponent {
   }
 
   render() {
+
+    console.log('input props',this.props,this.props.customGeneSets)
+
     return (
       <tr className={BaseStyle.openGeneSetRow} >
         <td colSpan={3} width={DETAIL_WIDTH+LABEL_WIDTH+DETAIL_WIDTH}>
@@ -79,9 +82,9 @@ export class OpenGeneSetRow extends PureComponent {
                     {/*<option>CC Gene Set</option>*/}
                     <option>----Custom Gene Sets----</option>
                     {
-                      // this.props.customGeneSets.map( gs => {
-                      //   return <option>{gs}</option>
-                      // })
+                      Object.keys(this.props.customGeneSets).map( gs => {
+                        return <option>{gs}</option>
+                      })
                     }
                     {/*<option>&nbsp;&nbsp;&nbsp;Custom Gene Set 1</option>*/}
                     {/*<option>&nbsp;&nbsp;&nbsp;Custom Gene Set 2</option>*/}

--- a/src/components/legend/OpenGeneSetRow.js
+++ b/src/components/legend/OpenGeneSetRow.js
@@ -20,21 +20,6 @@ export class OpenGeneSetRow extends PureComponent {
     }
   }
 
-  // handleGeneSetOption(value){
-  //
-  //   // this.setState({
-  //   //   selectedGeneSets: value
-  //   // })
-  // }
-
-  // componentDidUpdate(prevProps) {
-  // if(prevProps.selectedGeneSets!==this.props.selectedGeneSets){
-  //   this.setState({
-  //     selectedGeneSets: this.props.selectedGeneSets
-  //   })
-  // }
-  // }
-
   render() {
 
     return (
@@ -89,29 +74,19 @@ export class OpenGeneSetRow extends PureComponent {
                       value={this.props.selectedGeneSets}
                     >
                       <option>Default Gene Sets</option>
-                      {/*<option>BP Gene Set</option>*/}
-                      {/*<option>MF Gene Set</option>*/}
-                      {/*<option>CC Gene Set</option>*/}
                       <option>----Custom Gene Sets----</option>
                       {
                         Object.keys(this.props.customGeneSets).map( gs => {
                           return <option key={gs}>{gs}</option>
                         })
                       }
-                      {/*<option>&nbsp;&nbsp;&nbsp;Custom Gene Set 1</option>*/}
-                      {/*<option>&nbsp;&nbsp;&nbsp;Custom Gene Set 2</option>*/}
-                      {/*<option>&nbsp;&nbsp;&nbsp;Custom Gene Set 3</option>*/}
                     </select>
-                    {/*</td>*/}
-                    {/*<td>*/}
                     <button
                       className={BaseStyle.editGeneSets}
                       onClick={() =>this.props.onGeneEdit()}
                     >
                       <FaPlus style={{fontSize: 'small'}}/>
                     </button>
-                    {/*</td>*/}
-                    {/*<td>*/}
                     <button
                       className={BaseStyle.editGeneSets}
                       disabled={!this.props.isCustomGeneSet(this.props.selectedGeneSets)}

--- a/src/components/legend/OpenGeneSetRow.js
+++ b/src/components/legend/OpenGeneSetRow.js
@@ -40,12 +40,20 @@ export class OpenGeneSetRow extends PureComponent {
                 <td style={{height: 30}}>
                   <div className={BaseStyle.findNewGeneSets}
                   >
-                    <div className={BaseStyle.editGeneSetSearch}>Find</div>
+                    {/*<div className={BaseStyle.editGeneSetSearch}>Find</div>*/}
+                    <button
+                      className={BaseStyle.refreshButton}
+                      onClick={() => this.props.onChangeGeneSetLimit(this.state.geneSetLimit,this.state.sortGeneSetBy)}>
+                      Find <FaSearch/>
+                      {/*<FaSearch/>*/}
+                    </button>
+                    {/*<div className={BaseStyle.editGeneSetSearch}>Find</div>*/}
+                    <div className={BaseStyle.editGeneSetSearch}>the</div>
                     <input
                       className={BaseStyle.editGeneSetLimits} onChange={(limit) => this.setState({geneSetLimit: limit.target.value})}
                       size={3} type='text'
                       value={this.state.geneSetLimit}/>
-                    <div className={BaseStyle.editGeneSetSearch}>Most</div>
+                    <div className={BaseStyle.editGeneSetSearch}>most</div>
                     <select
                       className={BaseStyle.editGeneSetOrder}
                       onChange={(method) => {
@@ -62,51 +70,47 @@ export class OpenGeneSetRow extends PureComponent {
                         )
                       }
                     </select>
+                    <div className={BaseStyle.editGeneSetSearch}>in </div>
+                    {/*  </div>*/}
+                    {/*</td>*/}
+                    {/*<td>*/}
+                    <select
+                      className={BaseStyle.geneSetSelector}
+                      onChange={(event) => this.handleGeneSetOption(event.target.value)}
+                      value={this.state.selectedGeneSet}
+                    >
+                      <option>Default Gene Sets</option>
+                      {/*<option>BP Gene Set</option>*/}
+                      {/*<option>MF Gene Set</option>*/}
+                      {/*<option>CC Gene Set</option>*/}
+                      <option>----Custom Gene Sets----</option>
+                      {
+                        Object.keys(this.props.customGeneSets).map( gs => {
+                          return <option key={gs}>{gs}</option>
+                        })
+                      }
+                      {/*<option>&nbsp;&nbsp;&nbsp;Custom Gene Set 1</option>*/}
+                      {/*<option>&nbsp;&nbsp;&nbsp;Custom Gene Set 2</option>*/}
+                      {/*<option>&nbsp;&nbsp;&nbsp;Custom Gene Set 3</option>*/}
+                    </select>
+                    {/*</td>*/}
+                    {/*<td>*/}
                     <button
-                      className={BaseStyle.refreshButton}
-                      onClick={() => this.props.onChangeGeneSetLimit(this.state.geneSetLimit,this.state.sortGeneSetBy)}>
-                      Find <FaSearch/>
-                      {/*<FaSearch/>*/}
+                      className={BaseStyle.editGeneSets}
+                      onClick={() =>this.props.onGeneEdit()}
+                    >
+                      <FaPlus style={{fontSize: 'small'}}/>
+                    </button>
+                    {/*</td>*/}
+                    {/*<td>*/}
+                    <button
+                      className={BaseStyle.editGeneSets}
+                      disabled={!this.props.isCustomGeneSet(this.state.selectedGeneSet)}
+                      onClick={() =>this.props.onGeneEdit(this.state.selectedGeneSet.trim())}
+                    >
+                      <FaEdit style={{fontSize: 'small'}}/>
                     </button>
                   </div>
-                </td>
-                <td>
-                  <select
-                    className={BaseStyle.geneSetSelector}
-                    onChange={(event) => this.handleGeneSetOption(event.target.value)}
-                    value={this.state.selectedGeneSet}
-                  >
-                    <option>Default Gene Sets</option>
-                    {/*<option>BP Gene Set</option>*/}
-                    {/*<option>MF Gene Set</option>*/}
-                    {/*<option>CC Gene Set</option>*/}
-                    <option>----Custom Gene Sets----</option>
-                    {
-                      Object.keys(this.props.customGeneSets).map( gs => {
-                        return <option key={gs}>{gs}</option>
-                      })
-                    }
-                    {/*<option>&nbsp;&nbsp;&nbsp;Custom Gene Set 1</option>*/}
-                    {/*<option>&nbsp;&nbsp;&nbsp;Custom Gene Set 2</option>*/}
-                    {/*<option>&nbsp;&nbsp;&nbsp;Custom Gene Set 3</option>*/}
-                  </select>
-                </td>
-                <td>
-                  <button
-                    className={BaseStyle.editGeneSets}
-                    onClick={() =>this.props.onGeneEdit()}
-                  >
-                    <FaPlus style={{fontSize: 'small'}}/>
-                  </button>
-                </td>
-                <td>
-                  <button
-                    className={BaseStyle.editGeneSets}
-                    disabled={this.state.selectedGeneSet.indexOf('Custom')<0}
-                    onClick={() =>this.props.onGeneEdit(this.state.selectedGeneSet.trim())}
-                  >
-                    <FaEdit style={{fontSize: 'small'}}/>
-                  </button>
                 </td>
               </tr>
             </tbody>
@@ -120,7 +124,9 @@ export class OpenGeneSetRow extends PureComponent {
 OpenGeneSetRow.propTypes = {
   customGeneSets: PropTypes.any,
   geneSetLimit: PropTypes.any.isRequired,
+  isCustomGeneSet: PropTypes.any.isRequired,
   onChangeGeneSetLimit: PropTypes.any.isRequired,
   onGeneEdit: PropTypes.any.isRequired,
+  setActiveGeneSets: PropTypes.any.isRequired,
   sortGeneSetBy: PropTypes.any.isRequired,
 }

--- a/src/components/legend/OpenGeneSetRow.js
+++ b/src/components/legend/OpenGeneSetRow.js
@@ -83,7 +83,7 @@ export class OpenGeneSetRow extends PureComponent {
                     <option>----Custom Gene Sets----</option>
                     {
                       Object.keys(this.props.customGeneSets).map( gs => {
-                        return <option>{gs}</option>
+                        return <option key={gs}>{gs}</option>
                       })
                     }
                     {/*<option>&nbsp;&nbsp;&nbsp;Custom Gene Set 1</option>*/}

--- a/src/components/legend/OpenGeneSetRow.js
+++ b/src/components/legend/OpenGeneSetRow.js
@@ -17,13 +17,13 @@ export class OpenGeneSetRow extends PureComponent {
       geneSetLimit : props.geneSetLimit,
       sortGeneSetBy : props.sortGeneSetBy,
       sortGeneSetByLabel: props.sortGeneSetBy+ ' Gene Sets',
-      selectedGeneSet: 'BPA Gene Set Analysis',
+      selectedGeneSets: props.selectedGeneSets,
     }
   }
 
   handleGeneSetOption(value){
     this.setState({
-      selectedGeneSet: value
+      selectedGeneSets: value
     })
   }
 
@@ -43,7 +43,11 @@ export class OpenGeneSetRow extends PureComponent {
                     {/*<div className={BaseStyle.editGeneSetSearch}>Find</div>*/}
                     <button
                       className={BaseStyle.refreshButton}
-                      onClick={() => this.props.onChangeGeneSetLimit(this.state.geneSetLimit,this.state.sortGeneSetBy)}>
+                      onClick={() => this.props.onChangeGeneSetLimit(this.state.geneSetLimit,
+                        this.state.sortGeneSetBy,
+                        this.state.selectedGeneSets
+                      )
+                      }>
                       Find <FaSearch/>
                     </button>
                     <div className={BaseStyle.editGeneSetSearch}>the</div>
@@ -75,7 +79,7 @@ export class OpenGeneSetRow extends PureComponent {
                     <select
                       className={BaseStyle.geneSetSelector}
                       onChange={(event) => this.handleGeneSetOption(event.target.value)}
-                      value={this.state.selectedGeneSet}
+                      value={this.state.selectedGeneSets}
                     >
                       <option>Default Gene Sets</option>
                       {/*<option>BP Gene Set</option>*/}
@@ -103,8 +107,8 @@ export class OpenGeneSetRow extends PureComponent {
                     {/*<td>*/}
                     <button
                       className={BaseStyle.editGeneSets}
-                      disabled={!this.props.isCustomGeneSet(this.state.selectedGeneSet)}
-                      onClick={() =>this.props.onGeneEdit(this.state.selectedGeneSet.trim())}
+                      disabled={!this.props.isCustomGeneSet(this.state.selectedGeneSets)}
+                      onClick={() =>this.props.onGeneEdit(this.state.selectedGeneSets.trim())}
                     >
                       <FaEdit style={{fontSize: 'small'}}/>
                     </button>
@@ -125,6 +129,7 @@ OpenGeneSetRow.propTypes = {
   isCustomGeneSet: PropTypes.any.isRequired,
   onChangeGeneSetLimit: PropTypes.any.isRequired,
   onGeneEdit: PropTypes.any.isRequired,
+  selectedGeneSets: PropTypes.any,
   setActiveGeneSets: PropTypes.any.isRequired,
   sortGeneSetBy: PropTypes.any.isRequired,
 }

--- a/src/components/legend/OpenGeneSetRow.js
+++ b/src/components/legend/OpenGeneSetRow.js
@@ -17,19 +17,27 @@ export class OpenGeneSetRow extends PureComponent {
       geneSetLimit : props.geneSetLimit,
       sortGeneSetBy : props.sortGeneSetBy,
       sortGeneSetByLabel: props.sortGeneSetBy+ ' Gene Sets',
-      selectedGeneSets: props.selectedGeneSets,
     }
   }
 
-  handleGeneSetOption(value){
-    this.setState({
-      selectedGeneSets: value
-    })
-  }
+  // handleGeneSetOption(value){
+  //
+  //   // this.setState({
+  //   //   selectedGeneSets: value
+  //   // })
+  // }
+
+  // componentDidUpdate(prevProps) {
+  // if(prevProps.selectedGeneSets!==this.props.selectedGeneSets){
+  //   this.setState({
+  //     selectedGeneSets: this.props.selectedGeneSets
+  //   })
+  // }
+  // }
 
   render() {
 
-    console.log('input props',this.props,this.props.customGeneSets)
+    console.log('input props',this.props,this.props.customGeneSets,this.state.selectedGeneSets,this.props.selectedGeneSets)
 
     return (
       <tr className={BaseStyle.openGeneSetRow} >
@@ -78,8 +86,8 @@ export class OpenGeneSetRow extends PureComponent {
                     {/*<td>*/}
                     <select
                       className={BaseStyle.geneSetSelector}
-                      onChange={(event) => this.handleGeneSetOption(event.target.value)}
-                      value={this.state.selectedGeneSets}
+                      onChange={(event) => this.props.setGeneSetsOption(event.target.value)}
+                      value={this.props.selectedGeneSets}
                     >
                       <option>Default Gene Sets</option>
                       {/*<option>BP Gene Set</option>*/}
@@ -107,8 +115,8 @@ export class OpenGeneSetRow extends PureComponent {
                     {/*<td>*/}
                     <button
                       className={BaseStyle.editGeneSets}
-                      disabled={!this.props.isCustomGeneSet(this.state.selectedGeneSets)}
-                      onClick={() =>this.props.onGeneEdit(this.state.selectedGeneSets.trim())}
+                      disabled={!this.props.isCustomGeneSet(this.props.selectedGeneSets)}
+                      onClick={() =>this.props.onGeneEdit(this.props.selectedGeneSets.trim())}
                     >
                       <FaEdit style={{fontSize: 'small'}}/>
                     </button>
@@ -131,5 +139,6 @@ OpenGeneSetRow.propTypes = {
   onGeneEdit: PropTypes.any.isRequired,
   selectedGeneSets: PropTypes.any,
   setActiveGeneSets: PropTypes.any.isRequired,
+  setGeneSetsOption: PropTypes.any.isRequired,
   sortGeneSetBy: PropTypes.any.isRequired,
 }

--- a/src/components/legend/OpenGeneSetRow.js
+++ b/src/components/legend/OpenGeneSetRow.js
@@ -51,7 +51,8 @@ export class OpenGeneSetRow extends PureComponent {
                     {/*<div className={BaseStyle.editGeneSetSearch}>Find</div>*/}
                     <button
                       className={BaseStyle.refreshButton}
-                      onClick={() => this.props.onChangeGeneSetLimit(this.state.geneSetLimit,
+                      onClick={() => this.props.onChangeGeneSetLimit(
+                        this.state.geneSetLimit,
                         this.state.sortGeneSetBy,
                         this.state.selectedGeneSets
                       )

--- a/src/functions/FetchFunctions.js
+++ b/src/functions/FetchFunctions.js
@@ -101,7 +101,14 @@ export function calculateSelectedSubCohortSamples(availableSamples, cohort){
   }
 }
 
-export const getGeneSetsForView = (view) => {
+export const getGeneSetsForView = (view,selectedGeneSets) => {
+
+  console.log('got gene sets for view',selectedGeneSets)
+
+  if(selectedGeneSets){
+    return selectedGeneSets
+  }
+
   switch (view) {
   case VIEW_ENUM.PARADIGM:
     return ParadigmPathways

--- a/src/functions/FetchFunctions.js
+++ b/src/functions/FetchFunctions.js
@@ -101,13 +101,7 @@ export function calculateSelectedSubCohortSamples(availableSamples, cohort){
   }
 }
 
-export const getGeneSetsForView = (view,selectedGeneSets) => {
-
-  console.log('got gene sets for view',selectedGeneSets)
-
-  if(selectedGeneSets){
-    return selectedGeneSets
-  }
+export const getGeneSetsForView = (view) => {
 
   switch (view) {
   case VIEW_ENUM.PARADIGM:

--- a/src/functions/UrlFunctions.js
+++ b/src/functions/UrlFunctions.js
@@ -74,7 +74,7 @@ export function calculateCohorts(urlVariables){
   return [ AppStorageHandler.getCohortState(0), AppStorageHandler.getCohortState(1)]
 }
 
-export const generateUrl = (filter,geneset,genesetOpen,cohort1,cohort2,selectedSubCohorts1,selectedSubCohorts2,limit,sortViewByLabel) => {
+export const generateUrl = (filter,geneset,genesetOpen,cohort1,cohort2,selectedSubCohorts1,selectedSubCohorts2,limit,sortViewByLabel,selectedGeneSets) => {
   let generatedUrl = `cohort1=${cohort1}`
   generatedUrl += `&cohort2=${cohort2}`
   generatedUrl += `&filter=${filter}`
@@ -91,6 +91,9 @@ export const generateUrl = (filter,geneset,genesetOpen,cohort1,cohort2,selectedS
   }
   if(sortViewByLabel){
     generatedUrl += `&sortViewByLabel=${sortViewByLabel}`
+  }
+  if(selectedGeneSets){
+    generatedUrl += `&selectedGeneSets=${selectedGeneSets}`
   }
   return generatedUrl
 }

--- a/src/service/AppStorageHandler.js
+++ b/src/service/AppStorageHandler.js
@@ -81,7 +81,9 @@ export class AppStorageHandler {
 
   static getCustomPathways() {
     const storage = sessionStorage.getItem(LOCAL_CUSTOM_PATHWAYS_STORAGE)
-    return storage ? JSON.parse(storage) : {}
+    let DEFAULT_PATHWAYS = {}
+    Object.values(VIEW_ENUM).forEach( v => DEFAULT_PATHWAYS[v] = {} )
+    return storage ? JSON.parse(storage) : DEFAULT_PATHWAYS
   }
 
   static storeCustomPathways(pathways) {

--- a/src/service/AppStorageHandler.js
+++ b/src/service/AppStorageHandler.js
@@ -8,6 +8,7 @@ import {exception} from 'react-ga'
 // synchronizing gene sorts between pathways
 const LOCAL_APP_STORAGE = 'xena-app-storage'
 const LOCAL_STATE_STORAGE = 'xena-selection-storage'
+const LOCAL_CUSTOM_PATHWAYS_STORAGE = 'xena-custom-pathways-storage'
 const LOCAL_PATHWAY_STORAGE = 'default-xena-pathways'
 const LOCAL_SUBCOHORT_STORAGE = 'default-subcohort-storage'
 
@@ -69,12 +70,22 @@ export class AppStorageHandler {
     sessionStorage.removeItem(LOCAL_PATHWAY_STORAGE)
     sessionStorage.removeItem(LOCAL_STATE_STORAGE)
     sessionStorage.removeItem(LOCAL_SUBCOHORT_STORAGE)
+    sessionStorage.removeItem(LOCAL_CUSTOM_PATHWAYS_STORAGE)
   }
 
   static storePathways(pathways) {
     if (pathways) {
       sessionStorage.setItem(LOCAL_PATHWAY_STORAGE, JSON.stringify(pathways))
     }
+  }
+
+  static getCustomPathways() {
+    const storage = sessionStorage.getItem(LOCAL_CUSTOM_PATHWAYS_STORAGE)
+    return storage ? JSON.parse(storage) : {}
+  }
+
+  static storeCustomPathways(pathways) {
+    sessionStorage.setItem(LOCAL_CUSTOM_PATHWAYS_STORAGE,JSON.stringify(pathways))
   }
 
   static getPathways() {
@@ -168,7 +179,7 @@ export class AppStorageHandler {
       && cohortState.genomeBackgroundCopyNumber
       && cohortState.geneExpression
       && cohortState.geneExpressionPathwayActivity
-    
+
   }
 
   static isValidFilterState(filterState) {
@@ -180,14 +191,14 @@ export class AppStorageHandler {
     case VIEW_ENUM.REGULON:
       return true
     }
-    return false 
+    return false
   }
 
   static storeFilterState(selected) {
     if (!selected) return
     const appState = AppStorageHandler.getAppState()
     if (!appState.filterState) {
-      appState.filterState = undefined 
+      appState.filterState = undefined
     }
     // TODO: remove this hack
     appState.filterState = selected


### PR DESCRIPTION
fixes #613 

- [x] gene sets should be available to ONLY the SAME analysis method
- [x] test Paradigm IPL
- [x] test regulon
- [x] test CNV + Mutation (maybe disallow? )
- [x] test BPA Gene Expression


---

- [x] save and view should SET the limit <100 and use the sorting controls
- [x] save and view only available once name is provided
- [x] clean out unused 


---

- [x] "find" should do a search within the defined gene set
- [x] selected gene set should be persistent 
- [x] allow creation of new gene sets and saving inline
- [x] allow switching gene sets to existing or not 
- [x] delete gene sets from popup (for custom), and going back to the default option
- [x] selected gene set should map to the URL and trigger reload
- [x] store custom gene sets in app cache (first local, though)? 
- [x] allow name changing 

---

- [x] hide gene set editor for now if CNV + Mutation
