### PR TITLE
Integrate grails server

### DIFF
--- a/src/components/GeneSetEditorComponent.js
+++ b/src/components/GeneSetEditorComponent.js
@@ -24,6 +24,7 @@ export default class GeneSetEditorComponent extends PureComponent {
   render() {
 
     console.log('input gene set component',this.props.customGeneSets)
+    console.log('selected gene set component',this.props.selectedGeneSets)
 
     return (
       <div className={BaseStyle.findNewGeneSets}

--- a/src/components/GeneSetEditorComponent.js
+++ b/src/components/GeneSetEditorComponent.js
@@ -23,8 +23,8 @@ export default class GeneSetEditorComponent extends PureComponent {
 
   render() {
 
-    console.log('custom gene sets')
-    console.log(this.props.customGeneSets)
+    console.log('input gene set component',this.props.customGeneSets)
+
     return (
       <div className={BaseStyle.findNewGeneSets}
       >
@@ -76,7 +76,7 @@ export default class GeneSetEditorComponent extends PureComponent {
           <option>Default Gene Sets</option>
           {/*<option>----Custom Gene Sets----</option>*/}
           {
-            Object.keys(this.props.customGeneSets).map( gs => {
+            this.props.customGeneSets.map( gs => {
               return <option key={gs}>{gs}</option>
             })
           }

--- a/src/components/GeneSetEditorComponent.js
+++ b/src/components/GeneSetEditorComponent.js
@@ -22,6 +22,9 @@ export default class GeneSetEditorComponent extends PureComponent {
   }
 
   render() {
+
+    console.log('custom gene sets')
+    console.log(this.props.customGeneSets)
     return (
       <div className={BaseStyle.findNewGeneSets}
       >

--- a/src/components/GeneSetEditorPopup.js
+++ b/src/components/GeneSetEditorPopup.js
@@ -18,6 +18,7 @@ import Dialog from 'react-toolbox/lib/dialog'
 import {calculateSortingByMethod, scorePathway} from '../functions/SortFunctions'
 import {isViewGeneExpression} from '../functions/DataFunctions'
 import {SORT_ENUM, SORT_ORDER_ENUM, SORT_VIEW_BY} from '../data/SortEnum'
+import {getCustomGeneSet} from '../service/GeneSetAnalysisStorageService'
 
 const VIEW_LIMIT = 200
 const CART_LIMIT = 1000
@@ -98,7 +99,7 @@ export default class GeneSetEditorPopup extends PureComponent {
     return isViewGeneExpression(this.props.view)
   }
 
-  handleMeanActivityData = (output) => {
+  handleMeanActivityData = async (output) => {
     const pathways = getGeneSetsForView(this.props.view)
     let loadedPathways = pathways.map( p => {
       p.firstGeneExpressionPathwayActivity = undefined
@@ -124,10 +125,12 @@ export default class GeneSetEditorPopup extends PureComponent {
     let cartPathways
     if(this.props.customGeneSetName && this.props.isCustomGeneSet(this.state.customGeneSetName)){
       // TODO, may need to interset
-      cartPathways = this.props.getCustomGeneSet(this.state.customGeneSetName)
+      cartPathways = await getCustomGeneSet(this.props.view,this.state.customGeneSetName)
+      console.log('custom cart pathways',cartPathways)
     }
     else{
       cartPathways = loadedPathways.filter( p =>  pathwayLabels.indexOf(p.golabel)>=0 )
+      console.log('normal cart pathways',cartPathways)
       const cartLabels = cartPathways.map( p => p.golabel)
       cartPathways = [...cartPathways,...this.props.pathways.filter( p => cartLabels.indexOf(p.golabel)<0 )]
     }
@@ -690,7 +693,6 @@ GeneSetEditorPopup.propTypes = {
   cancelPathwayEdit: PropTypes.any.isRequired,
   customGeneSetName: PropTypes.any,
   getAvailableCustomGeneSets: PropTypes.any.isRequired,
-  getCustomGeneSet: PropTypes.any.isRequired,
   isCustomGeneSet: PropTypes.any.isRequired,
   pathwayData: PropTypes.array.isRequired,
   pathways: PropTypes.any.isRequired,

--- a/src/components/GeneSetSelector.js
+++ b/src/components/GeneSetSelector.js
@@ -164,6 +164,8 @@ export class GeneSetSelector extends PureComponent {
   render() {
     let {geneData,pathways, selectedPathway, topOffset, hoveredPathway, width, labelHeight, highlightedGene} = this.props
 
+    if(!selectedPathway) return <div />
+
     let yOffset = topOffset+4
 
     const layoutLength = pathways.length + (geneData && geneData[0].pathways ? geneData[0].pathways.length : 0)

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -104,7 +104,8 @@ export default class XenaGeneSetApp extends PureComponent {
   constructor(props) {
     super(props)
 
-    const pathways = AppStorageHandler.getPathways()
+    const pathways = AppStorageHandler.getDefaultPathways()
+    console.log('constructor pathways',pathways)
     const urlVariables = QueryString.parse(location.hash.substr(1))
 
     const filter = calculateFilter(urlVariables)
@@ -141,6 +142,7 @@ export default class XenaGeneSetApp extends PureComponent {
       selectedGeneSets: urlVariables.selectedGeneSets,
       customGeneSets: [],
       geneSetLimit: urlVariables.geneSetLimit ? urlVariables.geneSetLimit : DEFAULT_GENE_SET_LIMIT,
+      pathways,
       filter,
 
       sortViewByLabel,
@@ -196,10 +198,10 @@ export default class XenaGeneSetApp extends PureComponent {
     this.fetchData()
   }
 
-  getPathways() {
-    const storedPathways = AppStorageHandler.getPathways()
-    return this.state.pathways ? this.state.pathways : storedPathways
-  }
+  // getPathways() {
+  //   const storedPathways = AppStorageHandler.getPathways()
+  //   return this.state.pathways ? this.state.pathways : storedPathways
+  // }
 
   sortAndFetchPathways(pathways){
     console.log('sorting and fetch',pathways)
@@ -250,7 +252,8 @@ export default class XenaGeneSetApp extends PureComponent {
       this.setState({
         loading: LOAD_STATE.LOADING
       })
-      let pathways = this.getPathways()
+      // let pathways = this.getPathways()
+      let pathways = this.state.pathways
 
       console.log('INIT pathways', pathways)
 
@@ -569,7 +572,7 @@ export default class XenaGeneSetApp extends PureComponent {
     const associatedDataB = calculateAssociatedData(pathwayDataB,
       this.state.filter)
 
-    AppStorageHandler.storePathways(pathways)
+    // AppStorageHandler.storePathways(pathways)
     let selection = AppStorageHandler.getPathwaySelection()
     if (!selection ||
       !selection.pathway ||
@@ -726,7 +729,7 @@ export default class XenaGeneSetApp extends PureComponent {
     }
 
     AppStorageHandler.storePathwaySelection(pathwaySelectionWrapper)
-    const geneSetPathways = AppStorageHandler.getPathways()
+    const geneSetPathways = this.state.pathways
     const pureAssociatedData = [pruneGeneSelection(associatedData[0]), pruneGeneSelection(associatedData[1])]
 
     const sortedAssociatedDataA = sortAssociatedData(selection.pathway,
@@ -825,7 +828,7 @@ export default class XenaGeneSetApp extends PureComponent {
   }
 
   setActiveGeneSets = (newPathways, selectedGeneSets) => {
-    AppStorageHandler.storePathways(newPathways)
+    // AppStorageHandler.storePathways(newPathways)
 
     const defaultPathway = update(newPathways[0], {
       open: {$set: false},
@@ -1035,7 +1038,7 @@ export default class XenaGeneSetApp extends PureComponent {
       console.log('saved custom gene set data', customGeneSetData)
 
       AppStorageHandler.storeGeneSetsForView(gmtData, filter)
-      AppStorageHandler.storePathways(customGeneSetData)
+      // AppStorageHandler.storePathways(customGeneSetData)
       const samples = [[],[]]
       const {data} = await savePathwayResult(filter,gmt,selectedCohort,samples, customGeneSetData)
       // const {data} = await this.storeCustomGeneSet(uploadFileName, customGeneSetData)
@@ -1053,6 +1056,7 @@ export default class XenaGeneSetApp extends PureComponent {
         calculatingUpload: false,
         customGeneSets,
         selectedGeneSets: uploadFileName,
+        pathways: customGeneSetData,
         fetch: true, // triggers fetch here, but may not be
       })
     } catch (e) {
@@ -1093,7 +1097,6 @@ export default class XenaGeneSetApp extends PureComponent {
     const crosshairHeight = (((this.state.pathways ? this.state.pathways.length : 0) + ((this.state.geneData && this.state.geneData[0].pathways) ? this.state.geneData[0].pathways.length : 0)) * 22) + 200
 
     const allowableViews = intersection(getViewsForCohort(this.state.selectedCohort[0].name), getViewsForCohort(this.state.selectedCohort[1].name))
-    let pathways = this.getPathways()
 
 
     return (
@@ -1343,7 +1346,7 @@ export default class XenaGeneSetApp extends PureComponent {
                         geneData={this.state.geneData}
                         labelHeight={22}
                         maxValue={this.state.maxGeneData}
-                        pathways={pathways}
+                        pathways={this.state.pathways}
                         selectedPathway={this.state.pathwaySelection}
                         width={VERTICAL_GENESET_DETAIL_WIDTH}
                       />
@@ -1358,7 +1361,7 @@ export default class XenaGeneSetApp extends PureComponent {
                             onClick={this.handlePathwaySelect}
                             onHover={this.handlePathwayHover}
                             onMouseOut={this.handlePathwayHover}
-                            pathways={pathways}
+                            pathways={this.state.pathways}
                             selectedCohort={this.state.selectedCohort[0]}
                             selectedPathway={this.state.pathwaySelection}
                             width={VERTICAL_GENESET_DETAIL_WIDTH}
@@ -1391,7 +1394,7 @@ export default class XenaGeneSetApp extends PureComponent {
                         geneData={this.state.geneData}
                         labelHeight={22}
                         maxValue={this.state.maxGeneData}
-                        pathways={pathways}
+                        pathways={this.state.pathways}
                         selectedPathway={this.state.pathwaySelection}
                         width={VERTICAL_GENESET_DETAIL_WIDTH}
                       />
@@ -1406,7 +1409,7 @@ export default class XenaGeneSetApp extends PureComponent {
                             onClick={this.handlePathwaySelect}
                             onHover={this.handlePathwayHover}
                             onMouseOut={this.handlePathwayHover}
-                            pathways={pathways}
+                            pathways={this.state.pathways}
                             selectedCohort={this.state.selectedCohort[1]}
                             selectedPathway={this.state.pathwaySelection}
                             width={VERTICAL_GENESET_DETAIL_WIDTH}

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -941,9 +941,11 @@ export default class XenaGeneSetApp extends PureComponent {
       let analyzedData2 = doBpaAnalysisForCohorts(selectedCohort[1], gmtData, uploadFileName)
       const analyzedData = await Promise.all([analyzedData1, analyzedData2])
       const customGeneSetData = calculateCustomGeneSetActivity(gmtData, analyzedData)
+      console.log('saved custom gene set data',customGeneSetData)
 
       AppStorageHandler.storeGeneSetsForView(gmtData, filter)
-      this.storeCustomGeneSet(uploadFileName, customGeneSetData)
+      const {data} = await this.storeCustomGeneSet(uploadFileName, customGeneSetData)
+      console.log( data )
 
       this.setState({
         showUploadDialog: false,

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -307,12 +307,14 @@ export default class XenaGeneSetApp extends PureComponent {
     console.log('STATE: fetch',this.state.fetch)
     console.log('STATE: loading',this.state.loading,LOAD_STATE.UNLOADED)
     // currentLoadState = LOAD_STATE.UNLOADED
-    this.setState({
-      customGeneSets: internalCustomGeneSets,
-      selectedGeneSets: currentGeneSets,
-      loading: LOAD_STATE.UNLOADED,
-      fetch: true,
-    })
+    if(!isEqual(this.state.customGeneSets,internalCustomGeneSets) || !isEqual(this.state.loading,LOAD_STATE.LOADING)){
+      this.setState({
+        customGeneSets: internalCustomGeneSets,
+        selectedGeneSets: currentGeneSets,
+        loading: LOAD_STATE.UNLOADED,
+        fetch: true,
+      })
+    }
   }
 
   generateSubCohortText(selectedCohort) {
@@ -1006,7 +1008,6 @@ export default class XenaGeneSetApp extends PureComponent {
 
   render() {
     let maxValue = 0
-    console.log('XGSA RENDER')
 
     if (this.state.pathways) {
       if (isViewGeneExpression(this.state.filter)) {

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -273,11 +273,13 @@ export default class XenaGeneSetApp extends PureComponent {
     }
   }
 
-  async calculateCustomGeneSets(method, newGeneSet,cohortString) {
-    console.log('calculating custom gene set ', method, newGeneSet,cohortString)
+  async calculateCustomGeneSets(method, newGeneSet,cohort) {
+    console.log('calculating custom gene set ', method, newGeneSet,cohort)
     const view = method ? method : VIEW_ENUM.GENE_EXPRESSION
     // const customGeneSets = await getCustomGeneSetNames(view)
-    const customGeneSets = await getCustomGeneSetResult(view,newGeneSet,cohortString)
+    const cohortResultA = getCustomGeneSetResult(view,newGeneSet,cohort[0].name)
+    const cohortResultB = getCustomGeneSetResult(view,newGeneSet,cohort[1].name)
+    const customGeneSets = await Promise.all([cohortResultA,cohortResultB])
     // console.log('current gene sets ', customGeneSets)
     let internalCustomGeneSets = JSON.parse(JSON.stringify(this.state.customGeneSets))
     const currentGeneSets = newGeneSet !== undefined ? newGeneSet : this.state.selectedGeneSets

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -56,7 +56,6 @@ import GeneSetEditorPopup from './GeneSetEditorPopup'
 import {calculateCustomGeneSetActivity, doBpaAnalysisForCohorts, storeGmt} from '../service/AnalysisService'
 import {
   addCustomGeneSet,
-  getCustomGeneSet,
   getCustomGeneSetNames, getCustomGeneSetResult,
   removeCustomGeneSet
 } from '../service/GeneSetAnalysisStorageService'
@@ -178,6 +177,7 @@ export default class XenaGeneSetApp extends PureComponent {
 
   componentDidUpdate() {
     this.handleUrls()
+    console.log('component did update!',this.state.fetch,this.state.loading)
     this.fetchData()
   }
 
@@ -188,6 +188,7 @@ export default class XenaGeneSetApp extends PureComponent {
 
   fetchData() {
     if (this.doRefetch()) {
+      console.log('REFETCH triggered')
       // currentLoadState = LOAD_STATE.LOADING
       this.setState({
         loading: LOAD_STATE.LOADING
@@ -279,19 +280,32 @@ export default class XenaGeneSetApp extends PureComponent {
     // const customGeneSets = await getCustomGeneSetNames(view)
     const cohortResultA = getCustomGeneSetResult(view,newGeneSet,cohort[0].name)
     const cohortResultB = getCustomGeneSetResult(view,newGeneSet,cohort[1].name)
-    const customGeneSets = await Promise.all([cohortResultA,cohortResultB])
-    // console.log('current gene sets ', customGeneSets)
+    const selectedCustomGeneSet = await Promise.all([cohortResultA,cohortResultB])
+    console.log('current gene sets ', selectedCustomGeneSet)
+    console.log('all custom gene sets', this.state.customGeneSets)
     let internalCustomGeneSets = JSON.parse(JSON.stringify(this.state.customGeneSets))
     const currentGeneSets = newGeneSet !== undefined ? newGeneSet : this.state.selectedGeneSets
-    for (const geneSet of customGeneSets) {
-      // console.log('gene set', geneSet)
+    console.log('internal current gene sets ', internalCustomGeneSets)
+    console.log('selected gene set ',this.state.selectedGeneSets)
+    console.log('current gene set ',currentGeneSets)
+    for (const geneSet of selectedCustomGeneSet) {
+      console.log('gene set', geneSet)
       // add an empty result
-      if (this.state.selectedGeneSets === geneSet) {
-        internalCustomGeneSets[view][geneSet.name] = (await getCustomGeneSet(method, geneSet))[0]
+      if (this.state.selectedGeneSets === geneSet.gmt) {
+        console.log('matchted gene set',geneSet.gmt)
+        // const selectedGeneSetData = (await getCustomGeneSet(method, geneSet.gmt))
+        // console.log('getting the custom gene set set ',selectedGeneSetData)
+        // internalCustomGeneSets[geneSet.gmt] = selectedGeneSetData[0]
+        internalCustomGeneSets[geneSet.gmt] = selectedCustomGeneSet
       } else {
-        internalCustomGeneSets[view][geneSet.name] = {}
+        console.log('else ',geneSet.gmt)
+        internalCustomGeneSets[geneSet.gmt] = {}
       }
     }
+    console.log('STATE: output internal custom gene sets ',this.state.customGeneSets,internalCustomGeneSets)
+    console.log('STATE: currentGeneSets ',this.state.selectedGeneSets,currentGeneSets)
+    console.log('STATE: fetch',this.state.fetch)
+    console.log('STATE: loading',this.state.loading,LOAD_STATE.UNLOADED)
     // currentLoadState = LOAD_STATE.UNLOADED
     this.setState({
       customGeneSets: internalCustomGeneSets,
@@ -745,6 +759,7 @@ export default class XenaGeneSetApp extends PureComponent {
   };
 
   setGeneSetOption = (selectedGeneSets) => {
+    console.log('setting GENE SET OPTION')
     this.calculateCustomGeneSets(this.state.filter, selectedGeneSets,this.state.selectedCohort)
     this.setState({
       selectedGeneSets: selectedGeneSets,
@@ -991,6 +1006,7 @@ export default class XenaGeneSetApp extends PureComponent {
 
   render() {
     let maxValue = 0
+    console.log('XGSA RENDER')
 
     if (this.state.pathways) {
       if (isViewGeneExpression(this.state.filter)) {

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -944,8 +944,8 @@ export default class XenaGeneSetApp extends PureComponent {
       console.log('saved custom gene set data',customGeneSetData)
 
       AppStorageHandler.storeGeneSetsForView(gmtData, filter)
-      const {data} = await this.storeCustomGeneSet(uploadFileName, customGeneSetData)
-      console.log( data )
+      // const {data} = await this.storeCustomGeneSet(uploadFileName, customGeneSetData)
+      // console.log( data )
 
       this.setState({
         showUploadDialog: false,

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -275,11 +275,11 @@ export default class XenaGeneSetApp extends PureComponent {
     console.log('calculating custom gene set ', newGeneSet)
     const view = method ? method : VIEW_ENUM.GENE_EXPRESSION
     const customGeneSets = await getCustomGeneSetNames(view)
-    console.log('current gene sets ', customGeneSets)
+    // console.log('current gene sets ', customGeneSets)
     let internalCustomGeneSets = JSON.parse(JSON.stringify(this.state.customGeneSets))
     const currentGeneSets = newGeneSet !== undefined ? newGeneSet : this.state.selectedGeneSets
     for (const geneSet of customGeneSets) {
-      console.log('gene set', geneSet)
+      // console.log('gene set', geneSet)
       // add an empty result
       if (this.state.selectedGeneSets === geneSet) {
         internalCustomGeneSets[view][geneSet.name] = (await getCustomGeneSet(method, geneSet))[0]
@@ -449,8 +449,8 @@ export default class XenaGeneSetApp extends PureComponent {
       selectedCohorts,
     } = input
 
-    console.log('pathways', pathways)
-    console.log('from input', input)
+    // console.log('pathways', pathways)
+    // console.log('from input', input)
 
     const [geneExpressionZScoreA, geneExpressionZScoreB] = isViewGeneExpression(
       this.state.filter) ? generateZScoreForBoth(geneExpressionA, geneExpressionB)

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -205,7 +205,7 @@ export default class XenaGeneSetApp extends PureComponent {
 
   sortAndFetchPathways(pathways){
     console.log('sorting and fetch',pathways)
-    pathways.filter((a) => a.firstGeneExpressionPathwayActivity &&
+    const sortedPatwhays = pathways.filter((a) => a.firstGeneExpressionPathwayActivity &&
       a.secondGeneExpressionPathwayActivity)
       .sort((a, b) => (this.state.filterOrder === SORT_ORDER_ENUM.ASC ?
         1 :
@@ -224,9 +224,9 @@ export default class XenaGeneSetApp extends PureComponent {
         1 :
         -1) * (scorePathway(a, this.state.sortViewBy) -
         scorePathway(b, this.state.sortViewBy)))
-    console.log('output pathways', pathways)
+    console.log('output pathways', sortedPatwhays)
 
-    fetchCombinedCohorts(this.state.selectedCohort, pathways,
+    fetchCombinedCohorts(this.state.selectedCohort, sortedPatwhays,
       this.state.filter, this.handleCombinedCohortData)
 
   }
@@ -526,12 +526,13 @@ export default class XenaGeneSetApp extends PureComponent {
       selectedCohorts,
     } = input
 
-    // console.log('pathways', pathways)
-    // console.log('from input', input)
+    console.log('handleCombinedCohortData pathways', pathways)
+    console.log('handleCombinedCohortData from input', input)
 
     const [geneExpressionZScoreA, geneExpressionZScoreB] = isViewGeneExpression(
       this.state.filter) ? generateZScoreForBoth(geneExpressionA, geneExpressionB)
       : [geneExpressionA, geneExpressionB]
+    console.log('generated z scores')
 
     if (pathways[0].firstGeneExpressionSampleActivity && pathways.length === geneExpressionPathwayActivityA.length) {
       for (let index in pathways) {
@@ -568,8 +569,10 @@ export default class XenaGeneSetApp extends PureComponent {
       genomeBackgroundCopyNumber: genomeBackgroundCopyNumberB,
     }
 
+    console.log('calc ass data A')
     const associatedDataA = calculateAssociatedData(pathwayDataA,
       this.state.filter)
+    console.log('calc ass data B')
     const associatedDataB = calculateAssociatedData(pathwayDataB,
       this.state.filter)
 
@@ -585,16 +588,20 @@ export default class XenaGeneSetApp extends PureComponent {
       })
     }
 
+    console.log('sort ass data A')
     const sortedAssociatedDataA = sortAssociatedData(selection.pathway,
       associatedDataA, this.state.filter)
+    console.log('sort ass data B')
     const sortedAssociatedDataB = sortAssociatedData(selection.pathway,
       associatedDataB, this.state.filter)
+    console.log('output sort ass data B')
 
     const sortedSamplesA = sortedAssociatedDataA[0].map((d) => d.sample)
     const sortedSamplesB = sortedAssociatedDataB[0].map((d) => d.sample)
 
     pathways = calculateAllPathways([pathwayDataA, pathwayDataB],
       [sortedAssociatedDataA, sortedAssociatedDataB], this.state.filter)
+    console.log('calc all pathways')
     pathwayDataA.pathways = pathways
     pathwayDataB.pathways = pathways
     pathwayDataA.pathwaySelection = selection
@@ -604,9 +611,11 @@ export default class XenaGeneSetApp extends PureComponent {
 
     const geneData = selection && selection.open ? generateScoredData(selection, [pathwayDataA, pathwayDataB],
       pathways, this.state.filter, [sortedSamplesA, sortedSamplesB]) : [{}, {}]
+    console.log('gene data')
     const sortedGeneData = isViewGeneExpression(this.state.filter) && selection.open ?
       sortGeneDataWithSamples([sortedSamplesA, sortedSamplesB], geneData) :
       geneData
+    console.log('sorted gene data')
 
     let pathwayIndex = getSelectedGeneSetIndex(selection, pathways)
     const mergedGeneSetData = selection.open ? [

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -268,8 +268,9 @@ export default class XenaGeneSetApp extends PureComponent {
 
             fetchPathwayResult(this.state.filter, this.state.selectedGeneSets, this.state.selectedCohort, samples)
               .then( response => {
+                console.log('response',response)
                 if(response!==undefined && !isEmpty(response) ){
-                  pathways = JSON.parse(response.result)
+                  pathways = response
                 }
                 this.sortAndFetchPathways(pathways)
               })

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -1040,9 +1040,11 @@ export default class XenaGeneSetApp extends PureComponent {
       AppStorageHandler.storeGeneSetsForView(gmtData, filter)
       // AppStorageHandler.storePathways(customGeneSetData)
       const samples = [[],[]]
-      const {data} = await savePathwayResult(filter,gmt,selectedCohort,samples, customGeneSetData)
+      // const {data} = await savePathwayResult(filter,gmt,selectedCohort,samples, customGeneSetData)
+      await savePathwayResult(filter,gmt,selectedCohort,samples, customGeneSetData)
       // const {data} = await this.storeCustomGeneSet(uploadFileName, customGeneSetData)
-      console.log( data )
+      // console.log( data )
+      // console.log( JSON.stringify(data) )
       console.log('input custom gene set state',this.state.customGeneSets,uploadFileName)
       const customGeneSets = update(this.state.customGeneSets , {$push: [uploadFileName]} ).sort( (a,b) => {
         if(a.indexOf('Default')===0) return -1

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -172,20 +172,20 @@ export default class XenaGeneSetApp extends PureComponent {
     this.handleUrls()
     console.log('input state', this.state)
     // this.calculateCustomGeneSets()
-    this.getAvailableCustomGeneSets(this.state.customGeneSets, this.state.filter)
+    this.getAvailableCustomGeneSets(this.state.filter)
     this.fetchData()
   }
 
   componentDidUpdate(prevProps, prevState) {
     this.handleUrls()
-    console.log('component did update!', this.state, prevState)
-    console.log('keys A:', Object.keys(this.state).length)
-    console.log('keys B:', Object.keys(prevState).length)
+    // console.log('component did update!', this.state, prevState)
+    // console.log('keys A:', Object.keys(this.state).length)
+    // console.log('keys B:', Object.keys(prevState).length)
     let diffs = []
     for (const key of Object.keys(this.state)) {
       if (!isEqual(this.state[key], prevState[key])) {
-        console.log(key, isEqual(this.state[key], prevState[key]))
-        console.log(prevState[key] + ' -> ' + this.state[key])
+        // console.log(key, isEqual(this.state[key], prevState[key]))
+        // console.log(prevState[key] + ' -> ' + this.state[key])
         diffs.concat(key)
       }
     }
@@ -209,6 +209,8 @@ export default class XenaGeneSetApp extends PureComponent {
       })
       let pathways = this.getPathways()
 
+      console.log('INIT pathways', pathways)
+
       // if gene Expressions
       if (getCohortDataForGeneExpressionView(this.state.selectedCohort, this.state.filter) !== null) {
         if (this.state.reloadPathways) {
@@ -220,41 +222,43 @@ export default class XenaGeneSetApp extends PureComponent {
             if (Object.keys(this.state.customGeneSets).find(n => n === this.state.selectedGeneSets) === undefined) {
               console.log('calulcating custom gene sets')
               this.calculateCustomGeneSets(this.state.filter, this.state.selectedGeneSets, this.state.selectedCohort)
-            } else {
-              console.log('pull pathways out of custom gene set: ', this.state.customGeneSets, this.state.filter, this.state.selectedGeneSets)
-              console.log('result: ', this.state.customGeneSets, this.state.selectedGeneSets, this.state.customGeneSets.find(n => n.name === this.state.selectedGeneSets).result)
-              // pathways = await this.getComparisonResult(this.state.filter,this.state.selectedGeneSets,this.state.selectedCohort)
-              pathways = this.state.customGeneSets[this.state.selectedGeneSets].result
-                .filter((a) => a.firstGeneExpressionPathwayActivity &&
-                  a.secondGeneExpressionPathwayActivity)
-                .sort((a, b) => (this.state.filterOrder === SORT_ORDER_ENUM.ASC ?
-                  1 :
-                  -1) * (scorePathway(a, this.state.filterBy) -
-                  scorePathway(b, this.state.filterBy)))
-                // .filter( (c) => {
-                //   if(this.state.selectedGeneSets && this.state.selectedGeneSets.indexOf('Default')<0){
-                //   // only return custom gene sets with go labels?
-                //     const currentGeneSets = this.getCustomGeneSet(this.state.selectedGeneSets).map( f => f.golabel )
-                //     return currentGeneSets.indexOf(c.golabel)>=0
-                //   }
-                //   return true
-                // })
-                .slice(0, this.state.geneSetLimit)
-                .sort((a, b) => (this.state.sortViewOrder === SORT_ORDER_ENUM.ASC ?
-                  1 :
-                  -1) * (scorePathway(a, this.state.sortViewBy) -
-                  scorePathway(b, this.state.sortViewBy)))
-              console.log('output pathways', pathways)
-
-              fetchCombinedCohorts(this.state.selectedCohort, pathways,
-                this.state.filter, this.handleCombinedCohortData)
-
             }
+            console.log('pull pathways out of custom gene set: ', this.state.customGeneSets, this.state.filter, this.state.selectedGeneSets, this.state.selectedCohort)
+            // console.log('result: ', this.state.customGeneSets, this.state.selectedGeneSets, this.state.customGeneSets.find(n => n.name === this.state.selectedGeneSets).result)
+            // pathways = await this.getComparisonResult(this.state.filter,this.state.selectedGeneSets,this.state.selectedCohort)
+            // pathways = this.state.customGeneSets[this.state.selectedGeneSets].result
+            console.log('input pathways', AppStorageHandler.getPathways())
+            pathways = AppStorageHandler.getPathways()
+              .filter((a) => a.firstGeneExpressionPathwayActivity &&
+                a.secondGeneExpressionPathwayActivity)
+              .sort((a, b) => (this.state.filterOrder === SORT_ORDER_ENUM.ASC ?
+                1 :
+                -1) * (scorePathway(a, this.state.filterBy) -
+                scorePathway(b, this.state.filterBy)))
+              // .filter( (c) => {
+              //   if(this.state.selectedGeneSets && this.state.selectedGeneSets.indexOf('Default')<0){
+              //   // only return custom gene sets with go labels?
+              //     const currentGeneSets = this.getCustomGeneSet(this.state.selectedGeneSets).map( f => f.golabel )
+              //     return currentGeneSets.indexOf(c.golabel)>=0
+              //   }
+              //   return true
+              // })
+              .slice(0, this.state.geneSetLimit)
+              .sort((a, b) => (this.state.sortViewOrder === SORT_ORDER_ENUM.ASC ?
+                1 :
+                -1) * (scorePathway(a, this.state.sortViewBy) -
+                scorePathway(b, this.state.sortViewBy)))
+            console.log('output pathways', pathways)
+
+            fetchCombinedCohorts(this.state.selectedCohort, pathways,
+              this.state.filter, this.handleCombinedCohortData)
           } else {
             fetchBestPathways(this.state.selectedCohort, this.state.filter,
               this.handleMeanActivityData)
           }
         } else {
+          console.log('B pathways', pathways)
+
           fetchCombinedCohorts(this.state.selectedCohort, pathways,
             this.state.filter, this.handleCombinedCohortData)
         }
@@ -262,14 +266,17 @@ export default class XenaGeneSetApp extends PureComponent {
         // if its not gene expression just use the canned data
         if (!isViewGeneExpression(this.state.filter)) {
           pathways = getGeneSetsForView(this.state.filter)
+          console.log('C pathways', pathways)
         }
+        console.log('D pathways', pathways)
 
         fetchCombinedCohorts(this.state.selectedCohort, pathways,
           this.state.filter, this.handleCombinedCohortData)
       }
-    } else {
-      console.log('refetch NOT triggered', this.state.loading, this.state.fetch)
     }
+    // else {
+    //   console.log('refetch NOT triggered', this.state.loading, this.state.fetch)
+    // }
 
   }
 
@@ -304,38 +311,44 @@ export default class XenaGeneSetApp extends PureComponent {
     const selectedCustomGeneSet = await Promise.all([cohortResultA, cohortResultB])
     console.log('current gene sets ', selectedCustomGeneSet)
     console.log('all custom gene sets', this.state.customGeneSets)
-    let internalCustomGeneSets = JSON.parse(JSON.stringify(this.state.customGeneSets))
     const currentGeneSets = newGeneSet !== undefined ? newGeneSet : this.state.selectedGeneSets
-    console.log('internal current gene sets ', internalCustomGeneSets)
-    console.log('selected gene set ', this.state.selectedGeneSets)
-    console.log('current gene set ', currentGeneSets)
-    for (const geneSet of selectedCustomGeneSet) {
-      console.log('gene set', geneSet)
-      // add an empty result
-      if (this.state.selectedGeneSets === geneSet.gmt) {
-        console.log('matchted gene set', geneSet.gmt)
-        // const selectedGeneSetData = (await getCustomGeneSet(method, geneSet.gmt))
-        // console.log('getting the custom gene set set ',selectedGeneSetData)
-        // internalCustomGeneSets[geneSet.gmt] = selectedGeneSetData[0]
-        internalCustomGeneSets[geneSet.gmt] = selectedCustomGeneSet
-      } else {
-        console.log('else ', geneSet.gmt)
-        internalCustomGeneSets[geneSet.gmt] = {}
-      }
-    }
-    console.log('STATE: output internal custom gene sets ', this.state.customGeneSets, internalCustomGeneSets)
+    const pathways = AppStorageHandler.getPathways()
+    console.log('retrieved pathways', pathways)
+
+
+    // let internalCustomGeneSets = JSON.parse(JSON.stringify(this.state.customGeneSets))
+    // console.log('internal current gene sets ', internalCustomGeneSets)
+    // console.log('selected gene set ', this.state.selectedGeneSets)
+    // console.log('current gene set ', currentGeneSets)
+    // for (const geneSet of selectedCustomGeneSet) {
+    //   console.log('gene set', geneSet)
+    //   // add an empty result
+    //   if (this.state.selectedGeneSets === geneSet.gmt) {
+    //     console.log('matchted gene set', geneSet.gmt)
+    //     // const selectedGeneSetData = (await getCustomGeneSet(method, geneSet.gmt))
+    //     // console.log('getting the custom gene set set ',selectedGeneSetData)
+    //     // internalCustomGeneSets[geneSet.gmt] = selectedGeneSetData[0]
+    //     internalCustomGeneSets[geneSet.gmt] = selectedCustomGeneSet
+    //   } else {
+    //     console.log('else ', geneSet.gmt)
+    //     internalCustomGeneSets[geneSet.gmt] = {}
+    //   }
+    // }
+    //
+
+    // console.log('STATE: output internal custom gene sets ', this.state.customGeneSets, internalCustomGeneSets)
     console.log('STATE: currentGeneSets ', this.state.selectedGeneSets, currentGeneSets)
     console.log('STATE: fetch', this.state.fetch)
     console.log('STATE: loading', this.state.loading, LOAD_STATE.UNLOADED)
     // currentLoadState = LOAD_STATE.UNLOADED
-    if (!isEqual(this.state.customGeneSets, internalCustomGeneSets) || !isEqual(this.state.loading, LOAD_STATE.LOADING)) {
-      this.setState({
-        customGeneSets: internalCustomGeneSets,
-        selectedGeneSets: currentGeneSets,
-        loading: LOAD_STATE.LOADED,
-        fetch: true,
-      })
-    }
+    // if (!isEqual(this.state.customGeneSets, internalCustomGeneSets) || !isEqual(this.state.loading, LOAD_STATE.LOADING)) {
+    //   this.setState({
+    //     customGeneSets: internalCustomGeneSets,
+    //     selectedGeneSets: currentGeneSets,
+    //     loading: LOAD_STATE.LOADED,
+    //     fetch: true,
+    //   })
+    // }
   }
 
   generateSubCohortText(selectedCohort) {
@@ -736,7 +749,7 @@ export default class XenaGeneSetApp extends PureComponent {
 
   doRefetch() {
     // if (this.state.fetch && currentLoadState !== LOAD_STATE.LOADING) {
-    console.log('do refetch?', this.state.fetch, this.state.loading)
+    // console.log('do refetch?', this.state.fetch, this.state.loading)
     if (this.state.fetch && this.state.loading !== LOAD_STATE.LOADING) {
       return true
     }
@@ -906,8 +919,8 @@ export default class XenaGeneSetApp extends PureComponent {
     })
   }
 
-  getAvailableCustomGeneSets = async (inputGeneSets, method) => {
-    console.log('available custom gene sets', inputGeneSets, method)
+  getAvailableCustomGeneSets = async (method) => {
+    // console.log('available custom gene sets', inputGeneSets, method)
     const customGeneSets = await getCustomGeneSetNames(method)
     console.log('retrieved custom gene sets', customGeneSets)
     this.setState({
@@ -1004,6 +1017,7 @@ export default class XenaGeneSetApp extends PureComponent {
       console.log('saved custom gene set data', customGeneSetData)
 
       AppStorageHandler.storeGeneSetsForView(gmtData, filter)
+      AppStorageHandler.storePathways(customGeneSetData)
       // const {data} = await this.storeCustomGeneSet(uploadFileName, customGeneSetData)
       // console.log( data )
 

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -818,7 +818,7 @@ export default class XenaGeneSetApp extends PureComponent {
 
   setGeneSetOption = (selectedGeneSets) => {
     console.log('setting GENE SET OPTION')
-    this.calculateCustomGeneSets(this.state.filter, selectedGeneSets, this.state.selectedCohort)
+    // this.calculateCustomGeneSets(this.state.filter, selectedGeneSets, this.state.selectedCohort)
     this.setState({
       selectedGeneSets: selectedGeneSets,
     })

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -58,7 +58,7 @@ import {
   addCustomGeneSet,
   getCustomGeneSetNames,
   fetchPathwayResult,
-  getCustomGeneSetResult,
+  // getCustomGeneSetResult,
   removeCustomGeneSet, savePathwayResult
 } from '../service/GeneSetAnalysisStorageService'
 import {VIEW_ENUM} from '../data/ViewEnum'
@@ -317,57 +317,57 @@ export default class XenaGeneSetApp extends PureComponent {
     }
   }
 
-  async calculateCustomGeneSets(method, newGeneSet, cohort) {
-    console.log('calculating custom gene set ', method, newGeneSet, cohort)
-    // this.setState({
-    //   loading: LOAD_STATE.LOADING
-    // })
-    const view = method ? method : VIEW_ENUM.GENE_EXPRESSION
-    // const customGeneSets = await getCustomGeneSetNames(view)
-    const cohortResultA = getCustomGeneSetResult(view, newGeneSet, cohort[0].name)
-    const cohortResultB = getCustomGeneSetResult(view, newGeneSet, cohort[1].name)
-    const selectedCustomGeneSet = await Promise.all([cohortResultA, cohortResultB])
-    console.log('current gene sets ', selectedCustomGeneSet)
-    console.log('all custom gene sets', this.state.customGeneSets)
-    const currentGeneSets = newGeneSet !== undefined ? newGeneSet : this.state.selectedGeneSets
-    const pathways = AppStorageHandler.getPathways()
-    console.log('retrieved pathways', pathways)
-
-
-    // let internalCustomGeneSets = JSON.parse(JSON.stringify(this.state.customGeneSets))
-    // console.log('internal current gene sets ', internalCustomGeneSets)
-    // console.log('selected gene set ', this.state.selectedGeneSets)
-    // console.log('current gene set ', currentGeneSets)
-    // for (const geneSet of selectedCustomGeneSet) {
-    //   console.log('gene set', geneSet)
-    //   // add an empty result
-    //   if (this.state.selectedGeneSets === geneSet.gmt) {
-    //     console.log('matchted gene set', geneSet.gmt)
-    //     // const selectedGeneSetData = (await getCustomGeneSet(method, geneSet.gmt))
-    //     // console.log('getting the custom gene set set ',selectedGeneSetData)
-    //     // internalCustomGeneSets[geneSet.gmt] = selectedGeneSetData[0]
-    //     internalCustomGeneSets[geneSet.gmt] = selectedCustomGeneSet
-    //   } else {
-    //     console.log('else ', geneSet.gmt)
-    //     internalCustomGeneSets[geneSet.gmt] = {}
-    //   }
-    // }
-    //
-
-    // console.log('STATE: output internal custom gene sets ', this.state.customGeneSets, internalCustomGeneSets)
-    console.log('STATE: currentGeneSets ', this.state.selectedGeneSets, currentGeneSets)
-    console.log('STATE: fetch', this.state.fetch)
-    console.log('STATE: loading', this.state.loading, LOAD_STATE.UNLOADED)
-    // currentLoadState = LOAD_STATE.UNLOADED
-    // if (!isEqual(this.state.customGeneSets, internalCustomGeneSets) || !isEqual(this.state.loading, LOAD_STATE.LOADING)) {
-    //   this.setState({
-    //     customGeneSets: internalCustomGeneSets,
-    //     selectedGeneSets: currentGeneSets,
-    //     loading: LOAD_STATE.LOADED,
-    //     fetch: true,
-    //   })
-    // }
-  }
+  // async calculateCustomGeneSets(method, newGeneSet, cohort) {
+  //   console.log('calculating custom gene set ', method, newGeneSet, cohort)
+  //   // this.setState({
+  //   //   loading: LOAD_STATE.LOADING
+  //   // })
+  //   const view = method ? method : VIEW_ENUM.GENE_EXPRESSION
+  //   // const customGeneSets = await getCustomGeneSetNames(view)
+  //   const cohortResultA = getCustomGeneSetResult(view, newGeneSet, cohort[0].name)
+  //   const cohortResultB = getCustomGeneSetResult(view, newGeneSet, cohort[1].name)
+  //   const selectedCustomGeneSet = await Promise.all([cohortResultA, cohortResultB])
+  //   console.log('current gene sets ', selectedCustomGeneSet)
+  //   console.log('all custom gene sets', this.state.customGeneSets)
+  //   const currentGeneSets = newGeneSet !== undefined ? newGeneSet : this.state.selectedGeneSets
+  //   const pathways = AppStorageHandler.getPathways()
+  //   console.log('retrieved pathways', pathways)
+  //
+  //
+  //   // let internalCustomGeneSets = JSON.parse(JSON.stringify(this.state.customGeneSets))
+  //   // console.log('internal current gene sets ', internalCustomGeneSets)
+  //   // console.log('selected gene set ', this.state.selectedGeneSets)
+  //   // console.log('current gene set ', currentGeneSets)
+  //   // for (const geneSet of selectedCustomGeneSet) {
+  //   //   console.log('gene set', geneSet)
+  //   //   // add an empty result
+  //   //   if (this.state.selectedGeneSets === geneSet.gmt) {
+  //   //     console.log('matchted gene set', geneSet.gmt)
+  //   //     // const selectedGeneSetData = (await getCustomGeneSet(method, geneSet.gmt))
+  //   //     // console.log('getting the custom gene set set ',selectedGeneSetData)
+  //   //     // internalCustomGeneSets[geneSet.gmt] = selectedGeneSetData[0]
+  //   //     internalCustomGeneSets[geneSet.gmt] = selectedCustomGeneSet
+  //   //   } else {
+  //   //     console.log('else ', geneSet.gmt)
+  //   //     internalCustomGeneSets[geneSet.gmt] = {}
+  //   //   }
+  //   // }
+  //   //
+  //
+  //   // console.log('STATE: output internal custom gene sets ', this.state.customGeneSets, internalCustomGeneSets)
+  //   console.log('STATE: currentGeneSets ', this.state.selectedGeneSets, currentGeneSets)
+  //   console.log('STATE: fetch', this.state.fetch)
+  //   console.log('STATE: loading', this.state.loading, LOAD_STATE.UNLOADED)
+  //   // currentLoadState = LOAD_STATE.UNLOADED
+  //   // if (!isEqual(this.state.customGeneSets, internalCustomGeneSets) || !isEqual(this.state.loading, LOAD_STATE.LOADING)) {
+  //   //   this.setState({
+  //   //     customGeneSets: internalCustomGeneSets,
+  //   //     selectedGeneSets: currentGeneSets,
+  //   //     loading: LOAD_STATE.LOADED,
+  //   //     fetch: true,
+  //   //   })
+  //   // }
+  // }
 
   generateSubCohortText(selectedCohort) {
     if (
@@ -1040,10 +1040,14 @@ export default class XenaGeneSetApp extends PureComponent {
       const {data} = await savePathwayResult(filter,gmt,selectedCohort,samples, customGeneSetData)
       // const {data} = await this.storeCustomGeneSet(uploadFileName, customGeneSetData)
       console.log( data )
+      console.log('input custom gene set state',this.state.customGeneSets,uploadFileName)
+      const customGeneSets = update(this.state.customGeneSets , {$push: [uploadFileName]} )
+      console.log('output custom gene sets',customGeneSets)
 
       this.setState({
         showUploadDialog: false,
         calculatingUpload: false,
+        customGeneSets,
         selectedGeneSets: uploadFileName,
         fetch: true, // triggers fetch here, but may not be
       })

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -53,7 +53,7 @@ import {Button} from 'react-toolbox/lib'
 import {intersection} from '../functions/MathFunctions'
 import {getViewsForCohort} from '../functions/CohortFunctions'
 import GeneSetEditorPopup from './GeneSetEditorPopup'
-import {calculateCustomGeneSetActivity, doBpaAnalysisForCohorts} from '../service/AnalysisService'
+import {calculateCustomGeneSetActivity, doBpaAnalysisForCohorts, storeGmt} from '../service/AnalysisService'
 import {
   addCustomGeneSet,
   getCustomGeneSet,
@@ -952,9 +952,10 @@ export default class XenaGeneSetApp extends PureComponent {
         hasUploadFile: false,
         calculatingUpload: true,
       })
+      let gmt = await storeGmt(gmtData,uploadFileName,filter)
 
-      let analyzedData1 = doBpaAnalysisForCohorts(selectedCohort[0], gmtData, uploadFileName)
-      let analyzedData2 = doBpaAnalysisForCohorts(selectedCohort[1], gmtData, uploadFileName)
+      let analyzedData1 = doBpaAnalysisForCohorts(selectedCohort[0],  gmt.name,filter)
+      let analyzedData2 = doBpaAnalysisForCohorts(selectedCohort[1],  gmt.name,filter)
       const analyzedData = await Promise.all([analyzedData1, analyzedData2])
       const customGeneSetData = calculateCustomGeneSetActivity(gmtData, analyzedData)
       console.log('saved custom gene set data',customGeneSetData)

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -1041,7 +1041,11 @@ export default class XenaGeneSetApp extends PureComponent {
       // const {data} = await this.storeCustomGeneSet(uploadFileName, customGeneSetData)
       console.log( data )
       console.log('input custom gene set state',this.state.customGeneSets,uploadFileName)
-      const customGeneSets = update(this.state.customGeneSets , {$push: [uploadFileName]} )
+      const customGeneSets = update(this.state.customGeneSets , {$push: [uploadFileName]} ).sort( (a,b) => {
+        if(a.indexOf('Default')===0) return -1
+        if(b.indexOf('Default')===0) return 1
+        return a.toLowerCase()< b.toLowerCase() ? -1 : 1
+      })
       console.log('output custom gene sets',customGeneSets)
 
       this.setState({

--- a/src/functions/FetchFunctions.js
+++ b/src/functions/FetchFunctions.js
@@ -298,7 +298,9 @@ export function fetchSampleData(selectedCohorts,view, handleSampleDataCounts){
 
 // TODO: move into a service as an async method
 export function fetchCombinedCohorts(selectedCohorts, pathways,view, combinationHandler) {
+  console.log('fetch combined with pathways',pathways)
   const geneList = getGenesForPathways(pathways)
+  console.log('gene enes for pathways',geneList)
   let filterCounts
 
   function fetchDataForRegulon(selectedCohorts, samplesA,samplesB, geneList, geneSetLabels) {
@@ -436,14 +438,20 @@ export function fetchCombinedCohorts(selectedCohorts, pathways,view, combination
     getSamplesForCohortAndView(selectedCohorts[0],view),
     getSamplesForCohortAndView(selectedCohorts[1],view),
   ).flatMap( (unfilteredSamples) => {
+    console.log('got samples for cohort and view')
     filterCounts = [
       createFilterCountForView(unfilteredSamples[0], selectedCohorts[0], view),
       createFilterCountForView(unfilteredSamples[1], selectedCohorts[1], view),
     ]
 
+    console.log('got filter counts')
+
     const samplesA = calculateSelectedSubCohortSamples(unfilteredSamples[0], selectedCohorts[0])
+    console.log('samples A')
     const samplesB = calculateSelectedSubCohortSamples(unfilteredSamples[1], selectedCohorts[1])
+    console.log('samples B')
     const geneSetLabels = convertPathwaysToGeneSetLabel(pathways)
+    console.log('gene set labels')
 
     switch (view) {
     case VIEW_ENUM.GENE_EXPRESSION:
@@ -472,6 +480,7 @@ export function fetchCombinedCohorts(selectedCohorts, pathways,view, combination
       geneExpressionB, geneExpressionPathwayActivityB,
       samplesA,samplesB,
     }) => {
+      console.log('data actually returned')
       // TODO: should we just make everything there in terms of activty versus?
       combinationHandler({
         geneList,

--- a/src/service/AnalysisService.js
+++ b/src/service/AnalysisService.js
@@ -52,7 +52,14 @@ export async function doBpaAnalysisForCohorts(cohort, gmtData, geneSetName){
       }
     }
   )
-  const { data} = response
+  let { data} = response
+  console.log('parse',data.data)
+  const dataObject = JSON.parse(data.data)
+  console.log('data object')
+  console.log(dataObject)
+  data.data = dataObject.data
+  data.samples = dataObject.samples
+  console.log(data)
 
   return data
 
@@ -82,6 +89,8 @@ export function getDataStatisticsForGeneSet(arr){
 }
 
 export function getGeneSetNames(data){
+  console.log(data)
+  console.log(data.data)
   return data.data.map( d => {
     const name = d.geneset
     const goIndex = name.indexOf('(GO:')
@@ -168,6 +177,8 @@ export function createMeanMap(analyzedData) {
 }
 
 export function calculateCustomGeneSetActivity( gmtData, analyzedData){
+  console.log('data to analyze')
+  console.log(analyzedData)
   const meanMap = createMeanMap(analyzedData)
   // console.log('mean map')
   // console.log(meanMap)

--- a/src/service/AnalysisService.js
+++ b/src/service/AnalysisService.js
@@ -193,6 +193,25 @@ export function createMeanMap(analyzedData) {
   }
 }
 
+// // TODO:
+// async function getComparisonResult(filter, selectedGeneSets, selectedCohort) {
+//   // let formData = {}
+//   // formData['gmtdata'] = gmtData
+//   // formData['gmtname'] = geneSetName
+//   // formData['method'] = view
+//   // const response = await axios.post(`${BASE_URL}/gmt/store`,
+//   //   formData,
+//   //   {
+//   //     headers: {
+//   //       'Content-Type': 'application/json',
+//   //       'Access-Control-Allow-Origin': '*'
+//   //     }
+//   //   }
+//   // )
+//   // let { data} = response
+//   // return data
+// }
+
 export function calculateCustomGeneSetActivity( gmtData, analyzedData){
   console.log('data to analyze')
   console.log(analyzedData)

--- a/src/service/AnalysisService.js
+++ b/src/service/AnalysisService.js
@@ -22,14 +22,33 @@ function generateTpmFromCohort(cohort){
   return `${selectedCohort['geneExpression'].host}/download/${selectedCohort['geneExpression'].dataset}.gz`
 }
 
+export async function storeGmt(gmtData, geneSetName,view){
+
+  let formData = {}
+  formData['gmtdata'] = gmtData
+  formData['gmtname'] = geneSetName
+  formData['method'] = view
+  const response = await axios.post(`${BASE_URL}/gmt/store`,
+    formData,
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*'
+      }
+    }
+  )
+  let { data} = response
+  return data
+}
+
 /**
  * Emulating:  curl -v -F tpmdata=@test-data/TCGA-CHOL_logtpm_forTesting.tsv -F gmtdata=@test-data/Xena_manual_pathways.gmt http://localhost:8000/bpa_analysis
  * @param cohort
- * @param gmtData
  * @param geneSetName
+ * @param view
  * @returns {Promise<{msg: ({"TCGA.3X.AAV9.01A.TCGA.3X.AAVA.01A.TCGA.3X.AAVB.01A.TCGA.3X.AAVC.01A.TCGA.3X.AAVE.01A.TCGA.4G.AAZO.01A.TCGA.4G.AAZT.01A.TCGA.W5.AA2G.01A.TCGA.W5.AA2H.01A.TCGA.W5.AA2I.01A": string}|{"TCGA.3X.AAV9.01A.TCGA.3X.AAVA.01A.TCGA.3X.AAVB.01A.TCGA.3X.AAVC.01A.TCGA.3X.AAVE.01A.TCGA.4G.AAZO.01A.TCGA.4G.AAZT.01A.TCGA.W5.AA2G.01A.TCGA.W5.AA2H.01A.TCGA.W5.AA2I.01A": string}|{"TCGA.3X.AAV9.01A.TCGA.3X.AAVA.01A.TCGA.3X.AAVB.01A.TCGA.3X.AAVC.01A.TCGA.3X.AAVE.01A.TCGA.4G.AAZO.01A.TCGA.4G.AAZT.01A.TCGA.W5.AA2G.01A.TCGA.W5.AA2H.01A.TCGA.W5.AA2I.01A": string}|{"TCGA.3X.AAV9.01A.TCGA.3X.AAVA.01A.TCGA.3X.AAVB.01A.TCGA.3X.AAVC.01A.TCGA.3X.AAVE.01A.TCGA.4G.AAZO.01A.TCGA.4G.AAZT.01A.TCGA.W5.AA2G.01A.TCGA.W5.AA2H.01A.TCGA.W5.AA2I.01A": string}|{"TCGA.3X.AAV9.01A.TCGA.3X.AAVA.01A.TCGA.3X.AAVB.01A.TCGA.3X.AAVC.01A.TCGA.3X.AAVE.01A.TCGA.4G.AAZO.01A.TCGA.4G.AAZT.01A.TCGA.W5.AA2G.01A.TCGA.W5.AA2H.01A.TCGA.W5.AA2I.01A": string})[]}>}
  */
-export async function doBpaAnalysisForCohorts(cohort, gmtData, geneSetName){
+export async function doBpaAnalysisForCohorts(cohort,  geneSetName,view){
 
   // const tpmData = generateTpmFromCohort(cohort)
   // let formData = new FormData()
@@ -37,11 +56,10 @@ export async function doBpaAnalysisForCohorts(cohort, gmtData, geneSetName){
   // formData.append('tpmname',cohort.name)
   // formData.append('tpmurl',generateTpmFromCohort(cohort))
   let formData = {}
-  formData['gmtdata'] = gmtData
   formData['gmtname'] = geneSetName
   formData['cohort'] = cohort.name
   formData['tpmurl'] = generateTpmFromCohort(cohort)
-  formData['method'] = 'BPA'
+  formData['method'] = view
   // formData.append('input','text')
   const response = await axios.post(`${BASE_URL}/result/analyze`,
     formData,

--- a/src/service/AnalysisService.js
+++ b/src/service/AnalysisService.js
@@ -104,11 +104,14 @@ export function getValues(data){
  * @returns {*}
  */
 export function getDataStatisticsPerGeneSet(data){
-  const dataA = data[0]
-  const dataB = data[1]
+  console.log('data 0',data[0])
+  console.log('data 0 - test',data[0].map(d => d.data))
+  const dataA = data[0].map(d => d.data).map( e => e.map( f => parseFloat(f)))
+  const dataB = data[1].map(d => d.data).map( e => e.map( f => parseFloat(f)))
+  console.log('data A',dataA)
   let outputData = []
   for( const i in dataA){
-    const values = dataA[i].data.concat(dataB[i].data)
+    const values = dataA[i].concat(dataB[i])
     const {mean, variance} = getDataStatisticsForGeneSet(values)
     outputData.push({mean,variance})
   }
@@ -153,10 +156,14 @@ export function createMeanMap(analyzedData) {
   const samples = [getSamples(analyzedData[0]),getSamples(analyzedData[1])]
 
   const geneSetNames = getGeneSetNames(analyzedData[0])
+  console.log('gene set names ',geneSetNames)
   const values = getValues(analyzedData)
+  console.log('gene set values',values)
   const dataStatisticsPerGeneSet = getDataStatisticsPerGeneSet(values)
+  console.log('data set per gene set',values)
   // calculates cohorts separately
   const zSampleScores = [getZSampleScores(values[0],dataStatisticsPerGeneSet),getZSampleScores(values[1],dataStatisticsPerGeneSet)]
+  console.log('sample zScores',zSampleScores)
   // uses mean separately
   const zPathwayScores = getZPathwayScores(zSampleScores)
 
@@ -172,8 +179,8 @@ export function calculateCustomGeneSetActivity( gmtData, analyzedData){
   console.log('data to analyze')
   console.log(analyzedData)
   const meanMap = createMeanMap(analyzedData)
-  // console.log('mean map')
-  // console.log(meanMap)
+  console.log('mean map')
+  console.log(meanMap)
   return gmtData.split('\n')
     .filter( l => l.split('\t').length>2)
     .map( line => {

--- a/src/service/AnalysisService.js
+++ b/src/service/AnalysisService.js
@@ -1,6 +1,7 @@
 import axios from 'axios'
 import {getCohortDetails} from '../functions/CohortFunctions'
 import {average} from '../functions/DataFunctions'
+import {BASE_URL} from './GeneSetAnalysisStorageService'
 
 
 export function generateTpmDownloadUrlFromCohorts(cohorts){
@@ -42,7 +43,7 @@ export async function doBpaAnalysisForCohorts(cohort, gmtData, geneSetName){
   formData['tpmurl'] = generateTpmFromCohort(cohort)
   formData['method'] = 'BPA'
   // formData.append('input','text')
-  const response = await axios.post('http://localhost:3001/analyze',
+  const response = await axios.post(`${BASE_URL}/result/analyze`,
     formData,
     {
       headers: {

--- a/src/service/AnalysisService.js
+++ b/src/service/AnalysisService.js
@@ -53,14 +53,6 @@ export async function doBpaAnalysisForCohorts(cohort, gmtData, geneSetName){
     }
   )
   let { data} = response
-  console.log('parse',data.data)
-  const dataObject = JSON.parse(data.data)
-  console.log('data object')
-  console.log(dataObject)
-  data.data = dataObject.data
-  data.samples = dataObject.samples
-  console.log(data)
-
   return data
 
 }
@@ -90,8 +82,8 @@ export function getDataStatisticsForGeneSet(arr){
 
 export function getGeneSetNames(data){
   console.log(data)
-  console.log(data.data)
-  return data.data.map( d => {
+  console.log(data.genesets)
+  return data.genesets.map( d => {
     const name = d.geneset
     const goIndex = name.indexOf('(GO:')
     return goIndex > 0 ? name.substr(0,goIndex).trim() : name.trim()
@@ -99,7 +91,7 @@ export function getGeneSetNames(data){
 }
 
 export function getValuesForCohort(data){
-  return data.data
+  return data.genesets
 }
 
 export function getValues(data){

--- a/src/service/AppStorageHandler.js
+++ b/src/service/AppStorageHandler.js
@@ -9,7 +9,7 @@ import {exception} from 'react-ga'
 const LOCAL_APP_STORAGE = 'xena-app-storage'
 const LOCAL_STATE_STORAGE = 'xena-selection-storage'
 // const LOCAL_CUSTOM_PATHWAYS_STORAGE = 'xena-custom-pathways-storage'
-const LOCAL_PATHWAY_STORAGE = 'default-xena-pathways'
+// const LOCAL_PATHWAY_STORAGE = 'default-xena-pathways'
 const LOCAL_SUBCOHORT_STORAGE = 'default-subcohort-storage'
 const LOCAL_GENESETS_STORAGE = 'default-genesets-storage'
 
@@ -68,7 +68,7 @@ export class AppStorageHandler {
 
   static resetSessionStorage() {
     sessionStorage.removeItem(LOCAL_APP_STORAGE)
-    sessionStorage.removeItem(LOCAL_PATHWAY_STORAGE)
+    // sessionStorage.removeItem(LOCAL_PATHWAY_STORAGE)
     sessionStorage.removeItem(LOCAL_STATE_STORAGE)
     sessionStorage.removeItem(LOCAL_SUBCOHORT_STORAGE)
     // sessionStorage.removeItem(LOCAL_CUSTOM_PATHWAYS_STORAGE)
@@ -121,11 +121,11 @@ export class AppStorageHandler {
     return JSON.parse(sessionStorage.getItem(LOCAL_GENESETS_STORAGE))
   }
 
-  static storePathways(pathways) {
-    if (pathways) {
-      sessionStorage.setItem(LOCAL_PATHWAY_STORAGE, JSON.stringify(pathways))
-    }
-  }
+  // static storePathways(pathways) {
+  //   if (pathways) {
+  //     sessionStorage.setItem(LOCAL_PATHWAY_STORAGE, JSON.stringify(pathways))
+  //   }
+  // }
 
   // static getCustomPathways() {
   //   const storage = sessionStorage.getItem(LOCAL_CUSTOM_PATHWAYS_STORAGE)
@@ -138,9 +138,14 @@ export class AppStorageHandler {
   //   sessionStorage.setItem(LOCAL_CUSTOM_PATHWAYS_STORAGE,JSON.stringify(pathways))
   // }
 
-  static getPathways() {
-    const storedPathway = JSON.parse(sessionStorage.getItem(LOCAL_PATHWAY_STORAGE))
-    return storedPathway || DefaultPathWays
+  /**
+   * For some reason not working locally
+   * @returns {({goid: string, gene: string[], golabel: string}|{goid: string, gene: string[], golabel: string}|{goid: string, gene: string[], golabel: string}|{goid: string, gene: string[], golabel: string}|{goid: string, gene: [string, string, string], golabel: string})[]}
+   */
+  static getDefaultPathways() {
+    // const storedPathway = JSON.parse(sessionStorage.getItem(LOCAL_PATHWAY_STORAGE))
+    // return storedPathway || DefaultPathWays
+    return DefaultPathWays
   }
 
   static getDefaultSelectionPathway() {

--- a/src/service/GeneSetAnalysisStorageService.js
+++ b/src/service/GeneSetAnalysisStorageService.js
@@ -5,7 +5,9 @@ export const BASE_URL = 'http://localhost:8080'
 
 export async function getAllCustomGeneSets(){
   try {
+    console.log('getting alll custom gene sets ')
     const {data} = await axios.get(`${BASE_URL}/gmt`)
+    console.log(data)
     return data
   } catch (e) {
     // eslint-disable-next-line no-console
@@ -21,7 +23,7 @@ export async function getCustomGeneSetNames(method){
       'Access-Control-Allow-Origin': '*'
     }
   }
-  const {data} = await axios.get(`${BASE_URL}/gmt/${method}/all`,config)
+  const {data} = await axios.get(`${BASE_URL}/gmt/?method=${method}`,config)
   return data
 }
 

--- a/src/service/GeneSetAnalysisStorageService.js
+++ b/src/service/GeneSetAnalysisStorageService.js
@@ -73,3 +73,36 @@ export async function removeCustomGeneSet(method,geneSetName){
   return data
 }
 
+export async function fetchPathwayResult(method,gmt,selectedCohort,samples){
+  console.log('getting pathway result',method,gmt,selectedCohort,samples)
+  const config = {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+      'Access-Control-Allow-Origin': '*'
+    }
+  }
+  const {data} = await axios.get(`${BASE_URL}/compareResult/findResult?method=${method}&geneSetName=${gmt}&cohortNameA=${selectedCohort[0].name}&cohortNameB=${selectedCohort[1].name}&samples=${samples}`,config)
+  return data
+
+}
+
+export async function savePathwayResult(view,gmt,selectedCohort,samples, customGeneSetData){
+  const response = await axios.post(`${BASE_URL}/compareResult/storeResult`,
+    {
+      method: view,
+      geneset:gmt.name,
+      cohortA: selectedCohort[0].name,
+      cohortB: selectedCohort[1].name,
+      samples: samples,
+      result:customGeneSetData,
+    }
+    ,{
+      headers: {
+        'Access-Control-Allow-Origin': '*'
+      }
+    }
+  )
+  const { data} = response
+  return data
+}
+

--- a/src/service/GeneSetAnalysisStorageService.js
+++ b/src/service/GeneSetAnalysisStorageService.js
@@ -35,7 +35,7 @@ export async function getCustomGeneSet(method,geneSetName){
 }
 
 export async function addCustomGeneSet(method,geneSetName,inputData){
-  const response = await axios.post(`${BASE_URL}/gmt`,
+  const response = await axios.post(`${BASE_URL}/gmt/save`,
     {
       method,
       geneset:geneSetName,

--- a/src/service/GeneSetAnalysisStorageService.js
+++ b/src/service/GeneSetAnalysisStorageService.js
@@ -23,13 +23,19 @@ export async function getCustomGeneSetNames(method){
       'Access-Control-Allow-Origin': '*'
     }
   }
-  const {data} = await axios.get(`${BASE_URL}/gmt/?method=${method}`,config)
+  const {data} = await axios.get(`${BASE_URL}/gmt/names/?method=${method}`,config)
   return data
 }
 
 
 export async function getCustomGeneSet(method,geneSetName){
   const {data} = await axios.get(`${BASE_URL}/gmt/${method}/${geneSetName}`)
+  return data
+
+}
+
+export async function getCustomGeneSetResult(method,geneSetName,cohort){
+  const {data} = await axios.get(`${BASE_URL}/result/findResult/${method}/${geneSetName}/${cohort}`)
   return data
 
 }

--- a/src/service/GeneSetAnalysisStorageService.js
+++ b/src/service/GeneSetAnalysisStorageService.js
@@ -1,8 +1,11 @@
 import axios from 'axios'
 
+// TODO: configure to environment
+const BASE_URL = 'http://localhost:8080'
+
 export async function getAllCustomGeneSets(){
   try {
-    const {data} = await axios.get('http://localhost:3001/geneset')
+    const {data} = await axios.get(`${BASE_URL}/gmt`)
     return data
   } catch (e) {
     // eslint-disable-next-line no-console
@@ -18,19 +21,19 @@ export async function getCustomGeneSetNames(method){
       'Access-Control-Allow-Origin': '*'
     }
   }
-  const {data} = await axios.get(`http://localhost:3001/geneset/all/${method}`,config)
+  const {data} = await axios.get(`${BASE_URL}/gmt/${method}/all`,config)
   return data
 }
 
 
 export async function getCustomGeneSet(method,geneSetName){
-  const {data} = await axios.get(`http://localhost:3001/geneset/${method}/${geneSetName}`)
+  const {data} = await axios.get(`${BASE_URL}/geneset/${method}/${geneSetName}`)
   return data
 
 }
 
 export async function addCustomGeneSet(method,geneSetName,inputData){
-  const response = await axios.post('http://localhost:3001/geneset',
+  const response = await axios.post(`${BASE_URL}/geneset`,
     {
       method,
       geneset:geneSetName,
@@ -48,7 +51,7 @@ export async function addCustomGeneSet(method,geneSetName,inputData){
 }
 
 export async function removeCustomGeneSet(method,geneSetName){
-  const response = await axios.delete(`http://localhost:3001/geneset/${method}/${geneSetName}`)
+  const response = await axios.delete(`${BASE_URL}/geneset/${method}/${geneSetName}`)
   const { data} = response
   return data
 }

--- a/src/service/GeneSetAnalysisStorageService.js
+++ b/src/service/GeneSetAnalysisStorageService.js
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 // TODO: configure to environment
-const BASE_URL = 'http://localhost:8080'
+export const BASE_URL = 'http://localhost:8080'
 
 export async function getAllCustomGeneSets(){
   try {

--- a/src/service/GeneSetAnalysisStorageService.js
+++ b/src/service/GeneSetAnalysisStorageService.js
@@ -27,13 +27,13 @@ export async function getCustomGeneSetNames(method){
 
 
 export async function getCustomGeneSet(method,geneSetName){
-  const {data} = await axios.get(`${BASE_URL}/geneset/${method}/${geneSetName}`)
+  const {data} = await axios.get(`${BASE_URL}/gmt/${method}/${geneSetName}`)
   return data
 
 }
 
 export async function addCustomGeneSet(method,geneSetName,inputData){
-  const response = await axios.post(`${BASE_URL}/geneset`,
+  const response = await axios.post(`${BASE_URL}/gmt`,
     {
       method,
       geneset:geneSetName,
@@ -51,7 +51,7 @@ export async function addCustomGeneSet(method,geneSetName,inputData){
 }
 
 export async function removeCustomGeneSet(method,geneSetName){
-  const response = await axios.delete(`${BASE_URL}/geneset/${method}/${geneSetName}`)
+  const response = await axios.delete(`${BASE_URL}/gmt/${method}/${geneSetName}`)
   const { data} = response
   return data
 }

--- a/src/service/GeneSetAnalysisStorageService.js
+++ b/src/service/GeneSetAnalysisStorageService.js
@@ -34,8 +34,17 @@ export async function getCustomGeneSet(method,geneSetName){
 
 }
 
-export async function getCustomGeneSetResult(method,geneSetName,cohort){
-  const {data} = await axios.get(`${BASE_URL}/result/findResult/${method}/${geneSetName}/${cohort}`)
+export async function getCustomGeneSetResult(method,geneSetName,cohortName){
+  console.log('metho',method)
+  console.log('cohort',cohortName)
+  console.log('gene set name',geneSetName)
+  const config = {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+      'Access-Control-Allow-Origin': '*'
+    }
+  }
+  const {data} = await axios.get(`${BASE_URL}/result/findResult/?method=${method}&geneSetName=${geneSetName}&cohort=${cohortName}`,config)
   return data
 
 }

--- a/tests/service/GeneSetAnalysisStorageService.test.js
+++ b/tests/service/GeneSetAnalysisStorageService.test.js
@@ -17,7 +17,7 @@ describe('GeneSet Analysis Storage Service Test', () => {
   })
 
   it('add custom gene set', async () => {
-    const addedCustomGeneSet = await addCustomGeneSet('BPA','test123.gmt',{input:'data'})
+    const addedCustomGeneSet = await addCustomGeneSet(VIEW_ENUM.GENE_EXPRESSION,'test123.gmt',{input:'data'})
     expect(addedCustomGeneSet).toBeDefined()
   })
 

--- a/tests/service/GeneSetAnalysisStorageService.test.js
+++ b/tests/service/GeneSetAnalysisStorageService.test.js
@@ -1,6 +1,10 @@
 import expect from 'expect'
 import {VIEW_ENUM} from '../../src/data/ViewEnum'
-import {getAllCustomGeneSets, getCustomGeneSetNames} from '../../src/service/GeneSetAnalysisStorageService'
+import {
+  addCustomGeneSet,
+  getAllCustomGeneSets,
+  getCustomGeneSetNames
+} from '../../src/service/GeneSetAnalysisStorageService'
 
 
 describe('GeneSet Analysis Storage Service Test', () => {
@@ -12,17 +16,23 @@ describe('GeneSet Analysis Storage Service Test', () => {
     }, 0)
   })
 
-  // it('Find all custom gene sets', async () => {
-  //   const customGeneSetNames = await getAllCustomGeneSets()
-  //   console.log(customGeneSetNames)
-  //   // mostly we want to make sure its just an array
-  // })
+  it('add custom gene set', async () => {
+    const addedCustomGeneSet = await addCustomGeneSet('BPA','test123.gmt',{input:'data'})
+    expect(addedCustomGeneSet).toBeDefined()
+  })
+
+  it('Find all custom gene sets', async () => {
+    const customGeneSetNames = await getAllCustomGeneSets()
+    console.log(customGeneSetNames)
+    expect(addedCustomGeneSet).toBeDefined()
+    // mostly we want to make sure its just an array
+  })
   //
-  // it('Find custom gene sets', async () => {
-  //   const customGeneSetNames = await getCustomGeneSetNames(VIEW_ENUM.GENE_EXPRESSION)
-  //   console.log(customGeneSetNames)
-  //   // mostly we want to make sure its just an array
-  // })
+  it('Find custom gene sets', async () => {
+    const customGeneSetNames = await getCustomGeneSetNames(VIEW_ENUM.GENE_EXPRESSION)
+    console.log(customGeneSetNames)
+    // mostly we want to make sure its just an array
+  })
 })
 
 

--- a/tests/service/GeneSetAnalysisStorageService.test.js
+++ b/tests/service/GeneSetAnalysisStorageService.test.js
@@ -24,7 +24,7 @@ describe('GeneSet Analysis Storage Service Test', () => {
   it('Find all custom gene sets', async () => {
     const customGeneSetNames = await getAllCustomGeneSets()
     console.log(customGeneSetNames)
-    expect(addedCustomGeneSet).toBeDefined()
+    expect(customGeneSetNames).toBeDefined()
     // mostly we want to make sure its just an array
   })
   //


### PR DESCRIPTION
fixes https://github.com/ucscXena/XenaGoWidget/issues/655

- [ ] test: handle change of cohorts (re-do analysis / do activity calculations on the server? , provide a single server method with async processing):
  - [ ] handleChangeView, if newView is `BPA` and a custom geneset, query and do analysis, otherwise save
- [ ] implement: handle change of sub cohorts (# of samples) (move to separate ticket?)

---

- [ ] cleanup, etc.

--- 

- [x] test: viewable on upload of existing gmt with different name
- [x] test: set selected geneset on upload (currently you have to refresh) . . should be picked up by other 
- [x] test: functional without server
- [x] view on incognito site with the same URL
- [x] on changing cohort, needs to stay selected

---

- [x] store `BPA Method` instead of `BPA` as method , make retrieve method there
- [x] handle change gene set back to default
  - [x] handle reload
- [x] handle change gene set back from default to custom GMT
  - [x] handle reload
- [x] handle change gene set from custom GMT to custom GMT
  - [x] handle reload

---

- [x] handle changing view back and forth 
- [x] handle reload with other view

---

- [x] retrieved custom gene sets should always conform to the `pathways` model, or at least be saved that way
- [x] we need to store `custom gene set activity` results somewhere (in Results, with the extra cohort? ) or in ComparisonResult . . which will already have the proper data that is stored in pathways

