### PR TITLE
fixes #639

### DIFF
--- a/src/components/CohortEditorSelector.js
+++ b/src/components/CohortEditorSelector.js
@@ -8,9 +8,7 @@ import {
   getCohortDetails,
   getCohortsForView, getSamplesFromSelectedSubCohorts, getSubCohortsForCohort,
   getSubCohortsOnlyForCohort,
-  getViewsForCohort
 } from '../functions/CohortFunctions'
-import {intersection} from '../functions/MathFunctions'
 import update from 'immutability-helper'
 import Link from 'react-toolbox/lib/link'
 import {AppStorageHandler} from '../service/AppStorageHandler'
@@ -91,10 +89,6 @@ export class CohortEditorSelector extends PureComponent {
     this.updateSampleState(newCohortState)
   };
 
-  handleViewChange = (event) => {
-    this.setState({view: event.target.value})
-  };
-
   selectNone(cohortIndex){
     let newCohort = JSON.parse(JSON.stringify(this.state.cohort[cohortIndex]))
     // newCohort.selectedSubCohorts = newCohort.subCohorts ;
@@ -166,7 +160,6 @@ export class CohortEditorSelector extends PureComponent {
     const {  view, cohort , selectedSamples, availableSamples } = this.state
     const cohorts = getCohortsForView(view)
     const availableCohorts = fetchCohortData().filter( c => cohorts.indexOf(c.name)>=0 )
-    const allowableViews = intersection(getViewsForCohort(cohort[0].name),getViewsForCohort(cohort[1].name))
     const maximumSubCohorts = [getSubCohortsForCohort(cohort[0].name),getSubCohortsForCohort(cohort[1].name)]
 
     if(!subCohortCounts){
@@ -178,25 +171,6 @@ export class CohortEditorSelector extends PureComponent {
         <div>
           <table className={BaseStyle.cohortEditorBox}>
             <tbody>
-              <tr>
-                <td>
-                  <div
-                    style={{fontSize:'large',display:'inline',marginRight: 5, fontWeight: 'bolder',marginBottom: 100}}>
-                    Analysis</div>
-                  <select
-                    onChange={this.handleViewChange}
-                    value={view}
-                  >
-                    {
-                      Object.entries(allowableViews).map( f => {
-                        return (
-                          <option key={f[1]} value={f[1]}>{f[1]}</option>
-                        )
-                      })
-                    }
-                  </select>
-                </td>
-              </tr>
               <tr>
                 <td colSpan={3}>
                   <u>Current View:</u>Visualizing differences using '{view}'

--- a/src/components/GeneSetEditorComponent.js
+++ b/src/components/GeneSetEditorComponent.js
@@ -46,6 +46,36 @@ export default class GeneSetEditorComponent extends PureComponent {
     return (
       <div className={BaseStyle.findNewGeneSets}
       >
+        <div className={BaseStyle.editGeneSetSearch}><u>Gene Set</u>:</div>
+        <select
+          className={BaseStyle.geneSetSelector}
+          onChange={(event) => this.props.setGeneSetsOption(event.target.value)}
+          value={this.props.selectedGeneSets}
+        >
+          <option>public (8281) {DEFAULT_GENE_SETS}</option>
+          {/*<option>----Custom Internal Gene Sets----</option>*/}
+          {
+            this.props.customInternalGeneSets[this.props.view] &&
+            Object.entries(this.props.customInternalGeneSets[this.props.view]).map ( gs => {
+              return <option key={gs[1].geneset} value={gs[1].geneset}>local ({gs[1].result.length}) {gs[1].geneset}</option>
+            })
+          }
+          {/*<option>----Custom Server Gene Sets----</option>*/}
+          {
+            this.props.customServerGeneSets.map(gs => {
+              if(gs.ready){
+                return <option key={gs.name} value={gs.name}>{gs.public ? 'public' : gs.user } ({gs.geneCount}) {gs.name}</option>
+              }
+              else{
+                // note: geneCount is the GeneSetCount
+                return (<option disabled key={gs.name} value={gs.name}>
+                  Analyzing ( {gs.readyCount} of {gs.availableCount } ready ) –
+                  ({gs.geneCount}) {gs.name}
+                </option>)
+              }
+            })
+          }
+        </select>
         <ToolTipButton
           className={BaseStyle.editGeneSets}
           onClick={() =>this.props.handleGeneSetEdit()}
@@ -80,36 +110,6 @@ export default class GeneSetEditorComponent extends PureComponent {
             <FaUpload style={{fontSize: 'small'}}/>
           </ToolTipButton>
         }
-        <div className={BaseStyle.editGeneSetSearch}><u>Gene Set</u>:</div>
-        <select
-          className={BaseStyle.geneSetSelector}
-          onChange={(event) => this.props.setGeneSetsOption(event.target.value)}
-          value={this.props.selectedGeneSets}
-        >
-          <option>public (8281) {DEFAULT_GENE_SETS}</option>
-          {/*<option>----Custom Internal Gene Sets----</option>*/}
-          {
-            this.props.customInternalGeneSets[this.props.view] &&
-            Object.entries(this.props.customInternalGeneSets[this.props.view]).map ( gs => {
-              return <option key={gs[1].geneset} value={gs[1].geneset}>local ({gs[1].result.length}) {gs[1].geneset}</option>
-            })
-          }
-          {/*<option>----Custom Server Gene Sets----</option>*/}
-          {
-            this.props.customServerGeneSets.map(gs => {
-              if(gs.ready){
-                return <option key={gs.name} value={gs.name}>{gs.public ? 'public' : gs.user } ({gs.geneCount}) {gs.name}</option>
-              }
-              else{
-                // note: geneCount is the GeneSetCount
-                return (<option disabled key={gs.name} value={gs.name}>
-                  Analyzing ( {gs.readyCount} of {gs.availableCount } ready ) –
-                  ({gs.geneCount}) {gs.name}
-                </option>)
-              }
-            })
-          }
-        </select>
         <div className={BaseStyle.editGeneSetSearch}>Limit:</div>
         <input
           className={BaseStyle.editGeneSetLimits} onChange={(limit) => {

--- a/src/components/GeneSetEditorComponent.js
+++ b/src/components/GeneSetEditorComponent.js
@@ -9,6 +9,9 @@ import FaUpload from 'react-icons/lib/fa/upload'
 import FaMinus from 'react-icons/lib/fa/minus'
 import FaEdit from 'react-icons/lib/fa/edit'
 import {showXenaViewLink} from '../functions/DataFunctions'
+import Tooltip from 'react-toolbox/lib/tooltip'
+import Button from 'react-bootstrap/lib/Button'
+
 
 export const DEFAULT_GENE_SETS = 'Default Gene Sets'
 
@@ -38,36 +41,45 @@ export default class GeneSetEditorComponent extends PureComponent {
 
   render() {
 
+    const ToolTipButton = Tooltip(Button)
+
     return (
       <div className={BaseStyle.findNewGeneSets}
       >
-        <button
+        <ToolTipButton
           className={BaseStyle.editGeneSets}
           onClick={() =>this.props.handleGeneSetEdit()}
+          tooltip={'Add local gene set'}
         >
           <FaPlus style={{fontSize: 'small'}}/>
-        </button>
-        <button
+        </ToolTipButton>
+        { this.isNotCustomInternalGeneSet(this.props.selectedGeneSets) &&
+        <ToolTipButton
           className={BaseStyle.editGeneSets}
-          disabled={!this.isNotCustomInternalGeneSet(this.props.selectedGeneSets)}
           onClick={() =>this.props.handleGeneSetEdit(this.props.selectedGeneSets.trim())}
+          tooltip={'Edit local gene set'}
         >
           <FaEdit style={{fontSize: 'small'}}/>
-        </button>
-        <button
+        </ToolTipButton>
+        }
+        {!this.isNotEditable() &&
+        <ToolTipButton
           className={BaseStyle.editGeneSets}
-          disabled={this.isNotEditable()}
-          onClick={() =>this.props.handleGeneSetDelete(this.props.selectedGeneSets.trim())}
+          onClick={() => this.props.handleGeneSetDelete(this.props.selectedGeneSets.trim())}
+          tooltip={'Remove gene set'}
         >
           <FaMinus style={{fontSize: 'small'}}/>
-        </button>
-        <button
-          className={BaseStyle.editGeneSets}
-          disabled={!showXenaViewLink(this.props.view) || !this.props.profile}
-          onClick={() =>this.props.handleGeneSetUpload()}
-        >
-          <FaUpload style={{fontSize: 'small'}}/>
-        </button>
+        </ToolTipButton>
+        }
+        { showXenaViewLink(this.props.view) && this.props.profile && 
+          <ToolTipButton
+            className={BaseStyle.editGeneSets}
+            onClick={() => this.props.handleGeneSetUpload()}
+            tooltip={'Upload gene set'}
+          >
+            <FaUpload style={{fontSize: 'small'}}/>
+          </ToolTipButton>
+        }
         <div className={BaseStyle.editGeneSetSearch}><u>Gene Set</u>:</div>
         <select
           className={BaseStyle.geneSetSelector}

--- a/src/components/GeneSetEditorPopup.js
+++ b/src/components/GeneSetEditorPopup.js
@@ -333,7 +333,6 @@ export default class GeneSetEditorPopup extends PureComponent {
   handleViewGeneSets() {
     if(this.state.customGeneSetName){
       const selectedCartData = this.getSelectedCartData()
-      console.log('trying to save',this.state.customGeneSetName,selectedCartData)
       this.props.storeCustomInternalGeneSets(this.state.customGeneSetName,selectedCartData)
       this.props.setPathways(selectedCartData,this.state.customGeneSetName)
     }
@@ -699,6 +698,7 @@ GeneSetEditorPopup.propTypes = {
   cancelPathwayEdit: PropTypes.any.isRequired,
   customInternalGeneSetName: PropTypes.any,
   getAvailableCustomGeneSets: PropTypes.any.isRequired,
+  isExistingCustomInternalGeneSet: PropTypes.any.isRequired,
   isNotDefaultGeneSet: PropTypes.any.isRequired,
   pathwayData: PropTypes.array.isRequired,
   pathways: PropTypes.any.isRequired,

--- a/src/components/NavigationBar.js
+++ b/src/components/NavigationBar.js
@@ -99,7 +99,7 @@ export default class NavigationBar extends PureComponent {
                       <GoogleLogout
                         buttonText="Logout"
                         clientId={GOOGLE_APP_ID}
-                        onFailure={(err) => console.error('error', err)}
+                        onFailure={(err) => console.error('error', err)} // no-console
                         onLogoutSuccess={() => {
                           this.setUser()
                         }}

--- a/src/components/NavigationBar.js
+++ b/src/components/NavigationBar.js
@@ -88,7 +88,10 @@ export default class NavigationBar extends PureComponent {
                         clientId={GOOGLE_APP_ID}
                         cookiePolicy={'single_host_origin'}
                         isSignedIn
-                        onFailure={(err) => console.error('error', err)}
+                        onFailure={
+                          // eslint-disable-next-line no-console
+                          (err) => console.error('error', err)
+                        }
                         onSuccess={(response) => {
                           refreshTokenSetup(response)
                           this.setUser(response)
@@ -99,7 +102,10 @@ export default class NavigationBar extends PureComponent {
                       <GoogleLogout
                         buttonText="Logout"
                         clientId={GOOGLE_APP_ID}
-                        onFailure={(err) => console.error('error', err)} // no-console
+                        onFailure={
+                          // eslint-disable-next-line no-console
+                          (err) => console.error('error', err)
+                        }
                         onLogoutSuccess={() => {
                           this.setUser()
                         }}

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -1254,7 +1254,7 @@ export default class XenaGeneSetApp extends PureComponent {
             const topClient = ev.currentTarget.getBoundingClientRect().top
             // some fudge factors in here
             const x = ev.clientX + 9
-            const y = ev.clientY + 270 - topClient
+            const y = ev.clientY + 230 - topClient
             // if (    ((x >= 265 && x <= 445) || (x >= 673 && x <= 853)) ) {
             if (x >= 275 && x <= 865) {
               this.setState({mousing: true, x, y})

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -134,7 +134,7 @@ export default class XenaGeneSetApp extends PureComponent {
       geneSetLimit: urlVariables.geneSetLimit ? urlVariables.geneSetLimit : DEFAULT_GENE_SET_LIMIT,
       pathways,
       filter,
-
+      showLinkCopiedDialog: false,
       sortViewByLabel,
 
       filterBy,
@@ -1156,12 +1156,32 @@ export default class XenaGeneSetApp extends PureComponent {
           >
             <FaInfo/>
           </button>
+
+          {this.state.showLinkCopiedDialog &&
+          <Dialog
+            actions={[
+              {label:'Close',onClick: () => this.setState({showLinkCopiedDialog: false})}
+            ]}
+            active={this.state.showLinkCopiedDialog}
+            onEscKeyDown={() => this.setState({showLinkCopiedDialog: false})}
+            onOverlayClick={() => this.setState({showLinkCopiedDialog: false})}
+            theme={{
+              dialog: BaseStyle.cohortEditorDialogBase,
+              wrapper: BaseStyle.cohortEditorDialogWrapperBase,
+            }}
+            title="Link Copied to Clipboard!"
+          />
+          }
+
           <button
             className={BaseStyle.analysisTitleSelector}
             onClick={
               () => {
                 navigator.clipboard.writeText(location.href)
-                alert(`Link copied to clipboard: ${location.href}`)
+                this.setState({
+                  showLinkCopiedDialog:true
+                })
+                // alert(`Link copied to clipboard: ${location.href}`)
               }
             }
             title={'Copy Link to Clip Board'}

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -1273,7 +1273,7 @@ export default class XenaGeneSetApp extends PureComponent {
               dialog: BaseStyle.dialogBase,
               wrapper: BaseStyle.dialogWrapper,
             }}
-            title="Cohort Editor"
+            title="Cohort and Sub Group Editor"
           >
             <CohortEditorSelector
               cohort={this.state.selectedCohort}

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -77,7 +77,7 @@ export const MIN_FILTER = 2
 export const MAX_CNV_MUTATION_DIFF = 50
 
 export const DEFAULT_GENE_SET_LIMIT = 45
-export const LEGEND_HEIGHT = 140
+export const LEGEND_HEIGHT = 100
 export const HEADER_HEIGHT = 120
 export const DETAIL_WIDTH = 185
 export const LABEL_WIDTH = 220

--- a/src/components/XenaGeneSetApp.js
+++ b/src/components/XenaGeneSetApp.js
@@ -1161,7 +1161,7 @@ export default class XenaGeneSetApp extends PureComponent {
             onClick={
               () => {
                 navigator.clipboard.writeText(location.href)
-                alert('Link copied!')
+                alert(`Link copied to clipboard: ${location.href}`)
               }
             }
             title={'Copy Link to Clip Board'}

--- a/src/components/legend/GeneCnvMutationLegend.js
+++ b/src/components/legend/GeneCnvMutationLegend.js
@@ -15,7 +15,7 @@ export class GeneCnvMutationLegend extends PureComponent {
   render() {
 
     return (
-      <tr className={BaseStyle.geneLegend} >
+      <tr className={BaseStyle.geneSetLegend} >
         <td colSpan={1} width={DETAIL_WIDTH}>
           <GeneLegendLabel/>
         </td>

--- a/src/components/legend/GeneGeneExpressionLegend.js
+++ b/src/components/legend/GeneGeneExpressionLegend.js
@@ -44,7 +44,7 @@ export class GeneGeneExpressionLegend extends PureComponent {
   render() {
     return (
       // <tr style={{height: 50, fixed: 'position'}} >
-      <tr className={BaseStyle.geneLegend} >
+      <tr className={BaseStyle.geneSetLegend} >
         <td colSpan={1} width={DETAIL_WIDTH}>
           <GeneLegendLabel/>
         </td>

--- a/src/components/legend/GeneLegendLabel.js
+++ b/src/components/legend/GeneLegendLabel.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PureComponent from '../PureComponent'
-import BaseStyle from '../../css/base.css'
-import FaArrowRight from 'react-icons/lib/fa/arrow-right'
+// import BaseStyle from '../../css/base.css'
+// import FaArrowRight from 'react-icons/lib/fa/arrow-right'
 
 
 export class GeneLegendLabel extends PureComponent {
@@ -10,10 +10,11 @@ export class GeneLegendLabel extends PureComponent {
   render() {
 
     return (
-      <div className={BaseStyle.verticalLegendBox}>
-            Gene
-        <FaArrowRight/>
-      </div>
+      <div/>
+      // <div className={BaseStyle.verticalLegendBox}>
+      //       Gene
+      //   <FaArrowRight/>
+      // </div>
     )
   }
 

--- a/src/components/legend/GeneSetLegendLabel.js
+++ b/src/components/legend/GeneSetLegendLabel.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PureComponent from '../PureComponent'
-import BaseStyle from '../../css/base.css'
-import FaArrowRight from 'react-icons/lib/fa/arrow-right'
+// import BaseStyle from '../../css/base.css'
+// import FaArrowRight from 'react-icons/lib/fa/arrow-right'
 
 
 export class GeneSetLegendLabel extends PureComponent {
@@ -10,10 +10,11 @@ export class GeneSetLegendLabel extends PureComponent {
   render() {
 
     return (
-      <div className={BaseStyle.verticalLegendBox}>
-            Gene Set &nbsp;
-        <FaArrowRight/>
-      </div>
+      <div/>
+      // <div className={BaseStyle.verticalLegendBox}>
+      //       Gene Set &nbsp;
+      //   <FaArrowRight/>
+      // </div>
     )
   }
 

--- a/src/components/legend/LegendBox.js
+++ b/src/components/legend/LegendBox.js
@@ -44,10 +44,10 @@ export class LegendBox extends PureComponent {
 
 
               {/*Gene set layer*/}
-              {isViewGeneExpression(view) &&
+              {(!geneData || !geneData[0].data) && isViewGeneExpression(view) &&
             <GeneSetGeneExpressionLegend filter={view} maxValue={maxValue}/>
               }
-              {!isViewGeneExpression(view) &&
+              {(!geneData || !geneData[0].data) && !isViewGeneExpression(view) &&
             <GeneSetCnvMutationLegend/>
               }
 

--- a/src/components/legend/TopLegend.js
+++ b/src/components/legend/TopLegend.js
@@ -12,10 +12,14 @@ export class TopLegend extends PureComponent {
 
     return (
       <tr className={BaseStyle.middleSampleLegend}>
-        <td colSpan={1} width={DETAIL_WIDTH}/>
-        <td colSpan={1} width={LABEL_WIDTH}>
+        <td colSpan={1} width={DETAIL_WIDTH}>
           <FaArrowDown style={{marginLeft:60}}/>
-          <span className={BaseStyle.legendLabel}>Middle</span>
+          <span className={BaseStyle.legendLabel}>Sample</span>
+          <FaArrowDown/>
+        </td>
+        <td colSpan={1} width={LABEL_WIDTH}>
+          <FaArrowDown style={{marginLeft:40}}/>
+          <span className={BaseStyle.legendLabel}>Gene Set Summary</span>
           <FaArrowDown/>
         </td>
         <td colSpan={1} width={DETAIL_WIDTH}>

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -696,12 +696,12 @@ border-radius: 5px;
 
 .geneSetLegend{
   position: absolute;
-  margin-top: 30px;
+  margin-top: 25px;
 }
 
 .openGeneSetLegend{
   position: absolute;
-  margin-top: 110px;
+  margin-top: 65px;
   height: 42px;
 }
 

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -720,7 +720,7 @@ border-radius: 5px;
 }
 .diffScaleLegend{
   position: absolute;
-  margin-top: 122px;
+  margin-top: 80px;
 }
 
 .middleSampleLegend{

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -691,6 +691,7 @@ border-radius: 5px;
 
 .legendLabel{
   font-family: "Roboto", "Helvetica", "Arial", sans-serif;
+    font-size: small;
 }
 
 .geneSetLegend{

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -428,7 +428,7 @@
 }
 
 .editGeneSetOrder{
-  width: 155px;
+  width: 85px;
   display: inline;
 }
 

--- a/src/service/AppStorageHandler.js
+++ b/src/service/AppStorageHandler.js
@@ -113,7 +113,6 @@ export class AppStorageHandler {
     Object.values(VIEW_ENUM).forEach( (v) => {
       geneSetObject[v] = {}
     })
-    console.log('gene sets',geneSetObject)
     return this.storeGeneSets(geneSetObject)
   }
 
@@ -285,10 +284,8 @@ export class AppStorageHandler {
   }
 
   static storeCohortState(selected, cohortIndex) {
-    // console.log('storing cohort state',selected,cohortIndex)
     if (!selected) return
     const appState = AppStorageHandler.getAppState()
-    // console.log('RETR storing cohort state',appState)
     if (!appState.cohortState) {
       appState.cohortState = []
     }


### PR DESCRIPTION
fixes #639 

- ~~make "Analysis" part of "fetch results" now #729 ~~
- ~~add icons for server versus internal? (replace and set select class)~~
- ~~the arrows down / legends is hard for the eye to follow -> surround each section by box (gray?) #730~~
- ~~header bar has many problems: color scheme, layout#731~~

---

- [x] make `link copied` a proper popup dialog with a link clickable url
- [x] gray out `gene set legend` when you open up a list of genes or preferably swap it out
- [x] title for icons are wrong and should use tooltip if possible (everywhere)
- [x] move gene set to the left as it is a more important control and move icons to the right of that
- [x] call `Middle` -> `Summary` or word close to that ->  (i.e., `Gene Set Summary`)
- [x] `Sample` should go on both sides
- [x] change `Cohort Editor` editor popup -> `Cohort and Sub Group Editor` 
- [x] remove `Analysis` from Cohort Editor popup 
- [x] indicate the `link that is copied to clipboard`, show link, `link of current view is copied to the clipboard`
- [x] the information button does not match
- [x] find button should be a big "GO ->" button @jingchunzhu 
- [x] make distinction between local and server and default

